### PR TITLE
Synchronize CI workflow across projects

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -3,8 +3,8 @@
 maker=$1
 device=$2
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Build"
 make -j8
@@ -14,13 +14,13 @@ make -j8 install
 ls -R ${top}/install
 
 section "======================================== Verify build"
-ldd test/tester
+ldd_result=$(ldd test/tester)
+echo "${ldd_result}"
 
 # Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
-    ldd test/tester | grep cublas || exit 1
+    echo "${ldd_result}" | grep cublas || exit 1
 fi
 if [ "${device}" = "gpu_amd" ]; then
-    ldd test/tester | grep rocblas || exit 1
+    echo "${ldd_result}" | grep rocblas || exit 1
 fi
-

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
@@ -14,8 +14,9 @@ make -j8 install
 ls -R ${top}/install
 
 section "======================================== Verify build"
-# Verify that tester linked with cublas or rocblas as intended.
 ldd test/tester
+
+# Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
     ldd test/tester | grep cublas || exit 1
 fi

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -8,8 +8,8 @@ if [ "${maker}" = "cmake" ]; then
     mkdir -p build
 fi
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Verify dependencies"
 quiet module list

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -1,15 +1,25 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
 
-if [ "$maker" = "cmake" ]; then
-   rm -rf build
-   mkdir -p build
+if [ "${maker}" = "cmake" ]; then
+    rm -rf build
+    mkdir -p build
 fi
 
 mydir=`dirname $0`
 source $mydir/setup_env.sh
+
+section "======================================== Verify dependencies"
+quiet module list
+quiet which g++
+quiet g++ --version
+
+echo "MKLROOT=${MKLROOT}"
+
+section "======================================== Environment"
+env
 
 section "======================================== Setup build"
 export color=no

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
-jobs:          
+jobs:
   icl_blaspp:
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,4 +30,3 @@ jobs:
         run: .github/workflows/build.sh ${{matrix.maker}} ${{matrix.device}}
       - name: Test
         run: .github/workflows/test.sh ${{matrix.maker}} ${{matrix.device}}
-

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -17,7 +17,7 @@ quiet() {
 print_section() {
     builtin echo "$*"
     date
-    case "$save_flags" in
+    case "${save_flags}" in
         (*x*)  set -x
     esac
 }

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -1,20 +1,19 @@
 #!/bin/bash
 
-shopt -s expand_aliases
-
-set +x
-
-source /etc/profile
-
-top=`pwd`
+#-------------------------------------------------------------------------------
+# Functions
 
 # Suppress echo (-x) output of commands executed with `quiet`.
+# Useful for sourcing files, loading modules, spack, etc.
+# set +x, set -x are not echo'd.
 quiet() {
     { set +x; } 2> /dev/null;
     $@;
     set -x
 }
 
+# `section` is like `echo`, but suppresses output of the command itself.
+# https://superuser.com/a/1141026
 print_section() {
     builtin echo "$*"
     date
@@ -24,8 +23,19 @@ print_section() {
 }
 alias section='{ save_flags="$-"; set +x; } 2> /dev/null; print_section'
 
-module load gcc@7.3.0
-module load intel-mkl
+
+#-------------------------------------------------------------------------------
+quiet source /etc/profile
+
+hostname && pwd
+export top=`pwd`
+
+shopt -s expand_aliases
+
+
+section "======================================== Load compiler"
+quiet module load gcc@7.3.0
+quiet module load intel-mkl
 
 if [ "${device}" = "gpu_nvidia" ]; then
     section "======================================== Load CUDA"
@@ -49,23 +59,8 @@ fi
 
 if [ "${maker}" = "cmake" ]; then
     section "======================================== Load cmake"
-    module load cmake
+    quiet module load cmake
     which cmake
     cmake --version
     cd build
 fi
-
-
-section "======================================== Verify dependencies"
-module list
-
-which g++
-g++ --version
-
-echo "MKLROOT=${MKLROOT}"
-
-section "======================================== Environment"
-env
-
-set -x
-

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -3,8 +3,8 @@
 maker=$1
 device=$2
 
-mydir=`dirname $0`
-source $mydir/setup_env.sh
+mydir=$(dirname $0)
+source ${mydir}/setup_env.sh
 
 section "======================================== Tests"
 cd test

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe 
+#!/bin/bash -xe
 
 maker=$1
 device=$2
@@ -25,7 +25,7 @@ if [ "${maker}" = "make" ]; then
 fi
 if [ "${maker}" = "cmake" ]; then
     rm -rf build && mkdir build && cd build
-    cmake -DCMAKE_PREFIX_PATH=${top}/install/lib64/blaspp ..
+    cmake "-DCMAKE_PREFIX_PATH=${top}/install/lib64/blaspp" ..
 fi
 
 make

--- a/include/blas/rotg.hh
+++ b/include/blas/rotg.hh
@@ -34,7 +34,7 @@ namespace blas {
 ///     Cosine of rotation; real.
 ///
 /// @param[out] s
-///     Sine of rotation;   real.
+///     Sine of rotation; real.
 ///
 /// __Further details__
 ///


### PR DESCRIPTION
Fix minor differences so a multi-way diff
```
meld testsweeper/.github/workflows blaspp/.github/workflows lapackpp/.github/workflows
```
shows only significant changes, e.g., blaspp has devices.