### PR TITLE
Memcpy

### DIFF
--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -588,7 +588,7 @@ void device_memcpy(
 /// Copy nelements of type T from src to dst memory region.
 /// src and dst regions must not overlap.
 /// May be asynchronous with respect to host, depending on memory types;
-/// host memory may need to be pinned for this to by async.
+/// host memory may need to be pinned for this to be async.
 ///
 /// @param[out] dst
 ///     Pointer to destination memory region of size nelements.
@@ -673,7 +673,7 @@ void device_memcpy_2d(
 /// Copy width-by-height sub-array of type T from src to dst memory region.
 /// Sub-arrays of src and dst must not overlap.
 /// May be asynchronous with respect to host, depending on memory types;
-/// host memory may need to be pinned for this to by async.
+/// host memory may need to be pinned for this to be async.
 ///
 /// Memory here refers to 2D images, which by convention are
 /// width-by-height (e.g., 1024 x 768), and stored with contiguous rows.
@@ -727,7 +727,7 @@ void device_memcpy_2d(
 //------------------------------------------------------------------------------
 /// Copy n-element vector from host or device memory, to host or device memory.
 /// May be asynchronous with respect to host, depending on memory types;
-/// host memory may need to be pinned for this to by async.
+/// host memory may need to be pinned for this to be async.
 ///
 /// @param[in] n
 ///     Number of elements to copy. n >= 0.
@@ -767,7 +767,7 @@ void device_copy_vector(
 /// Copy m-by-n column-major matrix in ld-by-n array
 /// from host or device memory, to host or device memory.
 /// May be asynchronous with respect to host, depending on memory types;
-/// host memory may need to be pinned for this to by async.
+/// host memory may need to be pinned for this to be async.
 ///
 /// This is exactly the same as device_memcpy_2d, but with conventions
 /// consistent with BLAS/LAPACK routines: matrices are column-major;

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -658,8 +658,8 @@ void device_memcpy_2d(
             // Copy each contiguous image row (matrix column).
             // SYCL does not support set/get/lacpy matrix.
             for (int64_t i = 0; i < height; ++i) {
-                const T* dst_row = dst + i*dst_pitch;
-                T*       src_row = src + i*src_pitch;
+                T*       dst_row = dst + i*dst_pitch;
+                T const* src_row = src + i*src_pitch;
                 blas_dev_call(
                     queue.stream().memcpy( dst_row, src_row, width*sizeof(T) ) );
             }

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -525,12 +525,14 @@ void device_memset(
     int value, int64_t nelements, Queue& queue)
 {
     #ifdef BLAS_HAVE_CUBLAS
+        blas::set_device( queue.device() );
         blas_dev_call(
             cudaMemsetAsync(
                 ptr, value,
                 nelements * sizeof(T), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
+        blas::set_device( queue.device() );
         blas_dev_call(
             hipMemsetAsync(
                 ptr, value,
@@ -566,12 +568,14 @@ void device_memcpy(
     blas_error_if( nelements < 0 );
 
     #ifdef BLAS_HAVE_CUBLAS
+        blas::set_device( queue.device() );
         blas_dev_call(
             cudaMemcpyAsync(
                 dst, src, sizeof(T)*nelements,
                 memcpy2cuda(kind), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
+        blas::set_device( queue.device() );
         blas_dev_call(
             hipMemcpyAsync(
                 dst, src, sizeof(T)*nelements,
@@ -639,6 +643,7 @@ void device_memcpy_2d(
     blas_error_if( src_pitch < width );
 
     #ifdef BLAS_HAVE_CUBLAS
+        blas::set_device( queue.device() );
         blas_dev_call(
             cudaMemcpy2DAsync(
                 dst, sizeof(T)*dst_pitch,
@@ -646,7 +651,8 @@ void device_memcpy_2d(
                 sizeof(T)*width, height, memcpy2cuda(kind), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-         blas_dev_call(
+        blas::set_device( queue.device() );
+        blas_dev_call(
             hipMemcpy2DAsync(
                 dst, sizeof(T)*dst_pitch,
                 src, sizeof(T)*src_pitch,

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -563,6 +563,8 @@ void device_memcpy(
     T const* src,
     int64_t nelements, MemcpyKind kind, Queue& queue)
 {
+    blas_error_if( nelements < 0 );
+
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(
             cudaMemcpyAsync(
@@ -631,6 +633,8 @@ void device_memcpy_2d(
     T const* src, int64_t src_pitch,
     int64_t width, int64_t height, MemcpyKind kind, Queue& queue)
 {
+    blas_error_if( width  < 0 );
+    blas_error_if( height < 0 );
     blas_error_if( dst_pitch < width );
     blas_error_if( src_pitch < width );
 

--- a/include/blas/flops.hh
+++ b/include/blas/flops.hh
@@ -236,6 +236,10 @@ public:
     static double syr2( double n )
         { return her2( n ); }
 
+    // read A; write B
+    static double copy_2d( double m, double n )
+        { return 1e-9 * (2*m*n * sizeof(T)); }
+
     // ----------------------------------------
     // Level 3 BLAS
     // read A, B, C; write C

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,6 +70,8 @@ add_executable(
     test_herk.cc
     test_iamax.cc
     test_max.cc
+    test_memcpy.cc
+    test_memcpy_2d.cc
     test_nrm2.cc
     test_rot.cc
     test_rotg.cc

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -66,6 +66,8 @@ categories = [
     group_cat.add_argument( '--blas3-device', action='store_true', help='run Level 3 BLAS on devices (GPUs)' ),
     group_cat.add_argument( '--batch-blas3-device', action='store_true', help='run Level 3 Batch BLAS on devices (GPUs)' ),
 
+    group_cat.add_argument( '--aux', action='store_true', help='run auxiliary routines' ),
+
     group_cat.add_argument( '--device', action='store_true', help='run all GPU device routines' ),
 ]
 # map category objects to category names: ['lu', 'chol', ...]
@@ -372,6 +374,16 @@ if (opts.batch_blas3_device):
     [ 'dev-batch-syr2k', dtype_complex + batch + layout + align + uplo + trans_nt + mn ],
     ]
 
+if (opts.aux):
+    cmds += [
+    [ 'memcpy',      dtype + n ],
+    [ 'copy_vector', dtype + n + incx_pos + incy_pos ],
+    [ 'set_vector',  dtype + n + incx_pos + incy_pos ],
+
+    [ 'memcpy_2d',   dtype + mn + align ],
+    [ 'copy_matrix', dtype + mn + align ],
+    [ 'set_matrix',  dtype + mn + align ],
+    ]
 
 # ------------------------------------------------------------------------------
 # when output is redirected to file instead of TTY console,

--- a/test/test.cc
+++ b/test/test.cc
@@ -180,6 +180,12 @@ std::vector< testsweeper::routines_t > routines = {
     { "memcpy",           test_memcpy,              Section::aux            },
     { "copy_vector",      test_memcpy,              Section::aux            },
     { "set_vector",       test_memcpy,              Section::aux            },
+    { "",                 nullptr,                  Section::newline        },
+
+    { "memcpy_2d",        test_memcpy_2d,           Section::aux            },
+    { "copy_matrix",      test_memcpy_2d,           Section::aux            },
+    { "set_matrix",       test_memcpy_2d,           Section::aux            },
+    { "",                 nullptr,                  Section::newline        },
 };
 
 // -----------------------------------------------------------------------------

--- a/test/test.cc
+++ b/test/test.cc
@@ -169,12 +169,17 @@ std::vector< testsweeper::routines_t > routines = {
 
     { "dev-batch-trmm",   test_batch_trmm_device,   Section::device_blas3   },
     { "dev-batch-trsm",   test_batch_trsm_device,   Section::device_blas3   },
-    { "",                 nullptr,                  Section::newline },
+    { "",                 nullptr,                  Section::newline        },
 
     // auxiliary
-    { "error",  test_error,  Section::aux     },
-    { "max",    test_max,    Section::aux     },
-    { "util",   test_util,   Section::aux     },
+    { "error",            test_error,               Section::aux            },
+    { "max",              test_max,                 Section::aux            },
+    { "util",             test_util,                Section::aux            },
+    { "",                 nullptr,                  Section::newline        },
+
+    { "memcpy",           test_memcpy,              Section::aux            },
+    { "copy_vector",      test_memcpy,              Section::aux            },
+    { "set_vector",       test_memcpy,              Section::aux            },
 };
 
 // -----------------------------------------------------------------------------
@@ -189,35 +194,35 @@ Params::Params():
     // def = default
     // ----- test framework parameters
     //         name,       w,    type,         default, valid, help
-    check        ( "check",   0,    ParamType::Value, 'y', "ny",  "check the results" ),
-    ref          ( "ref",     0,    ParamType::Value, 'n', "ny",  "run reference; sometimes check -> ref" ),
+    check     ( "check",   0,    ParamType::Value, 'y', "ny",  "check the results" ),
+    ref       ( "ref",     0,    ParamType::Value, 'n', "ny",  "run reference; sometimes check -> ref" ),
 
-    //             name,      w, p, type,         default, min,  max, help
-    repeat       ( "repeat",  0,    ParamType::Value,   1,   1, 1000, "times to repeat each test" ),
-    verbose      ( "verbose", 0,    ParamType::Value,   0,   0,   10, "verbose level" ),
-    cache        ( "cache",   0,    ParamType::Value,  20,   1, 1024, "total cache size, in MiB" ),
+    //          name,      w, p, type,         default, min,  max, help
+    repeat    ( "repeat",  0,    ParamType::Value,   1,   1, 1000, "times to repeat each test" ),
+    verbose   ( "verbose", 0,    ParamType::Value,   0,   0,   10, "verbose level" ),
+    cache     ( "cache",   0,    ParamType::Value,  20,   1, 1024, "total cache size, in MiB" ),
 
     // ----- routine parameters
-    //             name,      w,    type,            def,                    char2enum,         enum2char,         enum2str,         help
-    datatype     ( "type",    4,    ParamType::List, DataType::Double,       char2datatype,     datatype2char,     datatype2str,     "s=single (float), d=double, c=complex-single, z=complex-double" ),
-    layout       ( "layout",  6,    ParamType::List, blas::Layout::ColMajor, blas::char2layout, blas::layout2char, blas::layout2str, "layout: r=row major, c=column major" ),
-    format       ( "format",  6,    ParamType::List, blas::Format::LAPACK,   blas::char2format, blas::format2char, blas::format2str, "format: l=lapack, t=tile" ),
-    side         ( "side",    6,    ParamType::List, blas::Side::Left,       blas::char2side,   blas::side2char,   blas::side2str,   "side: l=left, r=right" ),
-    uplo         ( "uplo",    6,    ParamType::List, blas::Uplo::Lower,      blas::char2uplo,   blas::uplo2char,   blas::uplo2str,   "triangle: l=lower, u=upper" ),
-    trans        ( "trans",   7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose: n=no-trans, t=trans, c=conj-trans" ),
-    transA       ( "transA",  7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose of A: n=no-trans, t=trans, c=conj-trans" ),
-    transB       ( "transB",  7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose of B: n=no-trans, t=trans, c=conj-trans" ),
-    diag         ( "diag",    7,    ParamType::List, blas::Diag::NonUnit,    blas::char2diag,   blas::diag2char,   blas::diag2str,   "diagonal: n=non-unit, u=unit" ),
+    //          name,      w,    type,            def,                    char2enum,         enum2char,         enum2str,         help
+    datatype  ( "type",    4,    ParamType::List, DataType::Double,       char2datatype,     datatype2char,     datatype2str,     "s=single (float), d=double, c=complex-single, z=complex-double" ),
+    layout    ( "layout",  6,    ParamType::List, blas::Layout::ColMajor, blas::char2layout, blas::layout2char, blas::layout2str, "layout: r=row major, c=column major" ),
+    format    ( "format",  6,    ParamType::List, blas::Format::LAPACK,   blas::char2format, blas::format2char, blas::format2str, "format: l=lapack, t=tile" ),
+    side      ( "side",    6,    ParamType::List, blas::Side::Left,       blas::char2side,   blas::side2char,   blas::side2str,   "side: l=left, r=right" ),
+    uplo      ( "uplo",    6,    ParamType::List, blas::Uplo::Lower,      blas::char2uplo,   blas::uplo2char,   blas::uplo2str,   "triangle: l=lower, u=upper" ),
+    trans     ( "trans",   7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose: n=no-trans, t=trans, c=conj-trans" ),
+    transA    ( "transA",  7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose of A: n=no-trans, t=trans, c=conj-trans" ),
+    transB    ( "transB",  7,    ParamType::List, blas::Op::NoTrans,      blas::char2op,     blas::op2char,     blas::op2str,     "transpose of B: n=no-trans, t=trans, c=conj-trans" ),
+    diag      ( "diag",    7,    ParamType::List, blas::Diag::NonUnit,    blas::char2diag,   blas::diag2char,   blas::diag2str,   "diagonal: n=non-unit, u=unit" ),
 
-    //             name,            w, p, type,            def,   min,     max, help
-    dim          ( "dim",           6,    ParamType::List,         0, 1000000, "m by n by k dimensions" ),
-    alpha        ( "alpha",         9, 4, ParamType::List,  pi,  -inf,     inf, "scalar alpha" ),
-    beta         ( "beta",          9, 4, ParamType::List,   e,  -inf,     inf, "scalar beta" ),
-    incx         ( "incx",          4,    ParamType::List,   1, -1000,    1000, "stride of x vector" ),
-    incy         ( "incy",          4,    ParamType::List,   1, -1000,    1000, "stride of y vector" ),
-    align        ( "align",         0,    ParamType::List,   1,     1,    1024, "column alignment (sets lda, ldb, etc. to multiple of align)" ),
-    batch        ( "batch",         6,    ParamType::List, 100,     0, 1000000, "batch size" ),
-    device       ( "device",        6,    ParamType::List,   0,     0,     100, "device id" ),
+    //          name,      w, p, type,            def,   min,     max, help
+    dim       ( "dim",     6,    ParamType::List,          0,     1e9, "m by n by k dimensions" ),
+    alpha     ( "alpha",   9, 4, ParamType::List,  pi,  -inf,     inf, "scalar alpha" ),
+    beta      ( "beta",    9, 4, ParamType::List,   e,  -inf,     inf, "scalar beta" ),
+    incx      ( "incx",    4,    ParamType::List,   1, -1000,    1000, "stride of x vector" ),
+    incy      ( "incy",    4,    ParamType::List,   1, -1000,    1000, "stride of y vector" ),
+    align     ( "align",   0,    ParamType::List,   1,     1,    1024, "column alignment (sets lda, ldb, etc. to multiple of align)" ),
+    batch     ( "batch",   6,    ParamType::List, 100,     0,     1e6, "batch size" ),
+    device    ( "device",  6,    ParamType::List,   0,     0,     100, "device id" ),
     pointer_mode ( "pointer-mode",  3,    ParamType::List, 'h',  "hd",          "h == host, d == device" ),
 
     // ----- output parameters
@@ -229,6 +234,18 @@ Params::Params():
     time      ( "BLAS++\ntime (s)", 11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution" ),
     gflops    ( "BLAS++\nGflop/s",  11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate" ),
     gbytes    ( "BLAS++\nGbyte/s",  11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate" ),
+
+    time2     ( "time2 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (2)" ),
+    gflops2   ( "Gflop2/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (2)" ),
+    gbytes2   ( "Gbyte2/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (2)" ),
+
+    time3     ( "time3 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (3)" ),
+    gflops3   ( "Gflop3/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (3)" ),
+    gbytes3   ( "Gbyte3/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (3)" ),
+
+    time4     ( "time4 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (4)" ),
+    gflops4   ( "Gflop4/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (4)" ),
+    gbytes4   ( "Gbyte4/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (4)" ),
 
     ref_time  ( "Ref.\ntime (s)",   11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference time to solution" ),
     ref_gflops( "Ref.\nGflop/s",    11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference Gflop/s rate" ),
@@ -303,6 +320,7 @@ int main( int argc, char** argv )
 
         // mark fields that are used (run=false)
         Params params;
+        params.routine = routine;
         test_routine( params, false );
 
         // Parse parameters up to routine name.

--- a/test/test.hh
+++ b/test/test.hh
@@ -191,7 +191,6 @@ void test_hemm_device  ( Params& params, bool run );
 void test_her2k_device ( Params& params, bool run );
 void test_herk_device  ( Params& params, bool run );
 void test_schur_gemm   ( Params& params, bool run );
-void test_schur_gemm_tile_layout ( Params& params, bool run );
 void test_symm_device  ( Params& params, bool run );
 void test_syr2k_device ( Params& params, bool run );
 void test_syrk_device  ( Params& params, bool run );
@@ -214,6 +213,7 @@ void test_error ( Params& params, bool run );
 void test_max   ( Params& params, bool run );
 void test_util  ( Params& params, bool run );
 void test_memcpy( Params& params, bool run );
+void test_memcpy_2d( Params& params, bool run );
 
 typedef long long llong;
 

--- a/test/test.hh
+++ b/test/test.hh
@@ -59,12 +59,26 @@ public:
     testsweeper::ParamDouble     gflops;
     testsweeper::ParamDouble     gbytes;
 
+    testsweeper::ParamDouble     time2;
+    testsweeper::ParamDouble     gflops2;
+    testsweeper::ParamDouble     gbytes2;
+
+    testsweeper::ParamDouble     time3;
+    testsweeper::ParamDouble     gflops3;
+    testsweeper::ParamDouble     gbytes3;
+
+    testsweeper::ParamDouble     time4;
+    testsweeper::ParamDouble     gflops4;
+    testsweeper::ParamDouble     gbytes4;
+
     testsweeper::ParamDouble     ref_time;
     testsweeper::ParamDouble     ref_gflops;
     testsweeper::ParamDouble     ref_gbytes;
 
     testsweeper::ParamOkay       okay;
     testsweeper::ParamString     msg;
+
+    std::string              routine;
 };
 
 // -----------------------------------------------------------------------------
@@ -199,5 +213,8 @@ void test_batch_trsm_device  ( Params& params, bool run );
 void test_error ( Params& params, bool run );
 void test_max   ( Params& params, bool run );
 void test_util  ( Params& params, bool run );
+void test_memcpy( Params& params, bool run );
+
+typedef long long llong;
 
 #endif        //  #ifndef TEST_HH

--- a/test/test.hh
+++ b/test/test.hh
@@ -123,6 +123,15 @@ void require_( bool cond, const char* condstr, const char* file, int line )
 #define require( cond ) require_( (cond), #cond, __FILE__, __LINE__ )
 
 // -----------------------------------------------------------------------------
+/// Synchronize the GPU queue, then return the current time in seconds.
+inline
+double sync_get_wtime( blas::Queue& queue )
+{
+    queue.sync();
+    return testsweeper::get_wtime();
+}
+
+// -----------------------------------------------------------------------------
 // Level 1 BLAS
 void test_asum  ( Params& params, bool run );
 void test_axpy  ( Params& params, bool run );

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -1,0 +1,274 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "print_matrix.hh"
+#include "lapack_wrappers.hh"
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void test_memcpy_work( Params& params, bool run )
+{
+    using namespace testsweeper;
+    using real_t = blas::real_type<T>;
+
+    // get & mark input values
+    int64_t n       = params.dim.n();
+    int64_t inc_ac  = params.incx();
+    int64_t inc_bd  = params.incy();
+    int64_t device  = params.device();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.time2();
+    params.time3();
+    params.time4();
+    params.gbytes();
+    params.gbytes2();
+    params.gbytes3();
+    params.gbytes4();
+    params.ref_time();
+    params.ref_gbytes();
+
+    params.time    .name( "h2d (sec)" );
+    params.time2   .name( "d2d (sec)" );
+    params.time3   .name( "d2h (sec)" );
+    params.time4   .name( "h2h (sec)" );
+    params.ref_time.name( "ref (sec)" );
+
+    params.gbytes    .name( "h2d GB/s" );
+    params.gbytes2   .name( "d2d GB/s" );
+    params.gbytes3   .name( "d2h GB/s" );
+    params.gbytes4   .name( "h2h GB/s" );
+    params.ref_gbytes.name( "ref GB/s" );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    enum class Method {
+        memcpy,
+        copy_vector,
+        set_vector,
+    };
+
+    Method method;
+    if (params.routine == "memcpy") {
+        method = Method::memcpy;
+        blas_error_if_msg( inc_ac != 1, "memcpy doesn't have inc" );
+        blas_error_if_msg( inc_bd != 1, "memcpy doesn't have inc" );
+    }
+    else if (params.routine == "copy_vector") {
+        method = Method::copy_vector;
+    }
+    else if (params.routine == "set_vector") {
+        method = Method::set_vector;
+    }
+    else {
+        throw blas::Error( "unknown method" );
+    }
+
+    // setup
+    // Allocate extra to verify copy doesn't overrun buffer.
+    // When routine is copy/set/get_vector,
+    // inc_ac is used for a, c vectors,
+    // inc_bd is used for b, d vectors.
+    int64_t inc = std::max( inc_ac, inc_bd );
+    int64_t extra = 2;
+    int64_t size = inc*(n + extra);
+    T* a_host = new T[ size ];
+    T* b_host = new T[ size ];
+    T* c_host = new T[ size ];
+    T* d_host = new T[ size ];
+
+    // device specifics
+    blas::Queue queue( device, 0 );
+    T* b_dev = blas::device_malloc<T>( size, queue );
+    T* c_dev = blas::device_malloc<T>( size, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size, a_host );
+    lapack_larnv( idist, iseed, size, b_host );
+    lapack_larnv( idist, iseed, size, c_host );
+    lapack_larnv( idist, iseed, size, d_host );
+
+    // test error exits
+    assert_throw( blas::device_memcpy( c_dev, b_dev, -1, queue ), blas::Error );
+
+    assert_throw( blas::device_copy_vector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
+
+    assert_throw( blas::device_setvector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_setvector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_setvector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
+
+    assert_throw( blas::device_getvector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_getvector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_getvector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "n=%5lld, inc_ac=%2lld, inc_bd=%2lld\n",
+                llong( n ), llong( inc_ac ), llong( inc_bd ) );
+    }
+    if (verbose >= 2) {
+        printf( "a = " ); print_matrix( inc_ac, n + extra, a_host, inc_ac );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+
+    //----------
+    // a_host -> b_dev
+    double time = get_wtime();
+    if (method == Method::memcpy) {
+        blas::device_memcpy( b_dev, a_host, n, queue );
+    }
+    else if (method == Method::copy_vector) {
+        blas::device_copy_vector( n, a_host, inc_ac, b_dev, inc_bd, queue );
+    }
+    else if (method == Method::set_vector) {
+        blas::device_setvector( n, a_host, inc_ac, b_dev, inc_bd, queue );
+    }
+    time = get_wtime() - time;
+
+    //----------
+    // b_dev -> c_dev
+    double time2 = get_wtime();
+    if (method == Method::memcpy) {
+        blas::device_memcpy( c_dev, b_dev, n, queue );
+    }
+    else if (method == Method::copy_vector || method == Method::set_vector) {
+        blas::device_copy_vector( n, b_dev, inc_bd, c_dev, inc_ac, queue );
+    }
+    time2 = get_wtime() - time2;
+
+    //----------
+    // c_dev -> d_host
+    double time3 = get_wtime();
+    if (method == Method::memcpy) {
+        blas::device_memcpy( d_host, c_dev, n, queue );
+    }
+    else if (method == Method::copy_vector) {
+        blas::device_copy_vector( n, c_dev, inc_ac, d_host, inc_bd, queue );
+    }
+    else if (method == Method::set_vector) {
+        blas::device_getvector( n, c_dev, inc_ac, d_host, inc_bd, queue );
+    }
+    time3 = get_wtime() - time3;
+
+    //----------
+    // a_host -> b_host
+    double time4 = get_wtime();
+    if (method == Method::copy_vector) {
+        blas::device_copy_vector( n, a_host, inc_ac, b_host, inc_bd, queue );
+    }
+    else {
+        // For method = memcpy or set_vector, use memcpy.
+        if (inc_ac == 1 && inc_bd == 1) {
+            // Contiguous copy.
+            blas::device_memcpy( b_host, a_host, n, queue );
+        }
+        else {
+            // Interpret as copying one row from inc-by-n matrix.
+            blas::device_memcpy_2d( b_host, inc_bd, a_host, inc_ac, 1, n, queue );
+        }
+    }
+    time4 = get_wtime() - time4;
+
+    //----------
+    // b_host -> c_host
+    double ref_time = get_wtime();
+    blas::copy( n, b_host, inc_bd, c_host, inc_ac );
+    ref_time = get_wtime() - ref_time;
+
+    // read n, write n
+    double gbyte = 2*n * 1e-9;
+
+    params.time()     = time;
+    params.time2()    = time2;
+    params.time3()    = time3;
+    params.time4()    = time4;
+    params.ref_time() = ref_time;
+
+    params.gbytes()     = gbyte / time;
+    params.gbytes2()    = gbyte / time2;
+    params.gbytes3()    = gbyte / time3;
+    params.gbytes4()    = gbyte / time4;
+    params.ref_gbytes() = gbyte / ref_time;
+
+    if (verbose >= 2) {
+        printf( "b = " ); print_matrix( inc_bd, n + extra, b_host, inc_bd );
+        printf( "c = " ); print_matrix( inc_ac, n + extra, c_host, inc_ac );
+        printf( "d = " ); print_matrix( inc_bd, n + extra, d_host, inc_bd );
+        printf( "Note rows after first and last %lld cols should NOT be copied!\n",
+                llong( extra ) );
+    }
+
+    // check error
+    blas::axpy( n, -1.0, a_host, inc_ac, b_host, inc_bd );
+    blas::axpy( n, -1.0, a_host, inc_ac, c_host, inc_ac );
+    blas::axpy( n, -1.0, a_host, inc_ac, d_host, inc_bd );
+    // Interpret as one row of inc-by-n matrix.
+    real_t dummy;
+    real_t error = lapack_lange( "m", 1, n, b_host, inc_bd, &dummy )
+                 + lapack_lange( "m", 1, n, c_host, inc_ac, &dummy )
+                 + lapack_lange( "m", 1, n, d_host, inc_bd, &dummy );
+    // Entries outside increments should NOT be copied.
+    // For first n cols, check i = 1 : inc.
+    // For extra   cols, check i = 0 : inc.
+    int64_t min_inc = std::min( inc_ac, inc_bd );
+    for (int64_t j = 0; j < n + extra; ++j) {
+        for (int64_t i = (j < n ? 1 : 0); i < min_inc; ++i) {
+            if (a_host[ i + j*inc_ac ] == b_host[ i + j*inc_bd ])
+                error += 1;
+            if (a_host[ i + j*inc_ac ] == c_host[ i + j*inc_ac ])
+                error += 1;
+            if (a_host[ i + j*inc_ac ] == d_host[ i + j*inc_bd ])
+                error += 1;
+        }
+    }
+    params.error() = error;
+    params.okay() = (error == 0);  // copy must be exact
+
+    delete[] a_host;
+    delete[] b_host;
+    delete[] c_host;
+    delete[] d_host;
+    blas::device_free( b_dev, queue );
+    blas::device_free( c_dev, queue );
+}
+
+// -----------------------------------------------------------------------------
+void test_memcpy( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_memcpy_work< float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_memcpy_work< double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_memcpy_work< std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_memcpy_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -76,6 +76,9 @@ void test_memcpy_work( Params& params, bool run )
     }
 
     // setup
+    if (verbose >= 1)
+        printf( "setup\n" );
+
     blas::Queue queue( device, 0 );
 
     // Allocate extra to verify copy doesn't overrun buffer.
@@ -102,6 +105,9 @@ void test_memcpy_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size, d_host );
 
     // test error exits
+    if (verbose >= 1)
+        printf( "error exits\n" );
+
     assert_throw( blas::device_memcpy( c_dev, b_dev, -1, queue ), blas::Error );
 
     assert_throw( blas::device_copy_vector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
@@ -130,6 +136,9 @@ void test_memcpy_work( Params& params, bool run )
 
     //----------
     // a_host -> b_dev
+    if (verbose >= 1)
+        printf( "a_host -> b_dev,  method %d\n", int( method ) );
+
     double time = sync_get_wtime( queue );
     if (method == Method::memcpy) {
         blas::device_memcpy( b_dev, a_host, n, queue );
@@ -144,6 +153,9 @@ void test_memcpy_work( Params& params, bool run )
 
     //----------
     // b_dev -> c_dev
+    if (verbose >= 1)
+        printf( "b_dev  -> c_dev,  method %d\n", int( method ) );
+
     double time2 = sync_get_wtime( queue );
     if (method == Method::memcpy) {
         blas::device_memcpy( c_dev, b_dev, n, queue );
@@ -156,6 +168,9 @@ void test_memcpy_work( Params& params, bool run )
 
     //----------
     // c_dev -> d_host
+    if (verbose >= 1)
+        printf( "c_dev  -> d_host, method %d\n", int( method ) );
+
     double time3 = sync_get_wtime( queue );
     if (method == Method::memcpy) {
         blas::device_memcpy( d_host, c_dev, n, queue );
@@ -170,6 +185,9 @@ void test_memcpy_work( Params& params, bool run )
 
     //----------
     // a_host -> b_host
+    if (verbose >= 1)
+        printf( "a_host -> b_host, method %d\n", int( method ) );
+
     double time4 = sync_get_wtime( queue );
     if (method == Method::memcpy) {
         blas::device_memcpy( b_host, a_host, n, queue );
@@ -182,6 +200,9 @@ void test_memcpy_work( Params& params, bool run )
 
     //----------
     // b_host -> c_host
+    if (verbose >= 1)
+        printf( "b_host -> c_host, method %d\n", int( method ) );
+
     double ref_time = sync_get_wtime( queue );
     blas::copy( n, b_host, inc_bd, c_host, inc_ac );
     ref_time = sync_get_wtime( queue ) - ref_time;
@@ -234,6 +255,9 @@ void test_memcpy_work( Params& params, bool run )
     }
     params.error() = error;
     params.okay() = (error == 0);  // copy must be exact
+
+    if (verbose >= 1)
+        printf( "cleanup\n" );
 
     blas::device_free_pinned( a_host, queue );
     blas::device_free_pinned( b_host, queue );

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -6,6 +6,7 @@
 #include "test.hh"
 #include "print_matrix.hh"
 #include "lapack_wrappers.hh"
+#include "blas/flops.hh"
 
 // -----------------------------------------------------------------------------
 template <typename T>
@@ -191,7 +192,7 @@ void test_memcpy_work( Params& params, bool run )
     ref_time = get_wtime() - ref_time;
 
     // read n, write n
-    double gbyte = 2*n * 1e-9;
+    double gbyte = blas::Gbyte<T>::copy( n );
 
     params.time()     = time;
     params.time2()    = time2;

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -6,6 +6,7 @@
 #include "test.hh"
 #include "print_matrix.hh"
 #include "lapack_wrappers.hh"
+#include "blas/flops.hh"
 
 // -----------------------------------------------------------------------------
 template <typename T>
@@ -186,7 +187,7 @@ void test_memcpy_2d_work( Params& params, bool run )
     ref_time = get_wtime() - ref_time;
 
     // read m*n, write m*n
-    double gbyte = 2*m*n * 1e-9;
+    double gbyte = blas::Gbyte<T>::copy_2d( m, n );
 
     params.time()     = time;
     params.time2()    = time2;

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -1,0 +1,267 @@
+// Copyright (c) 2017-2022, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "print_matrix.hh"
+#include "lapack_wrappers.hh"
+
+// -----------------------------------------------------------------------------
+template <typename T>
+void test_memcpy_2d_work( Params& params, bool run )
+{
+    using namespace testsweeper;
+    using real_t = blas::real_type<T>;
+
+    // get & mark input values
+    int64_t m       = params.dim.m();
+    int64_t n       = params.dim.n();
+    int64_t device  = params.device();
+    int64_t align   = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.time2();
+    params.time3();
+    params.time4();
+    params.gbytes();
+    params.gbytes2();
+    params.gbytes3();
+    params.gbytes4();
+    params.ref_time();
+    params.ref_gbytes();
+
+    params.time    .name( "h2d (sec)" );
+    params.time2   .name( "d2d (sec)" );
+    params.time3   .name( "d2h (sec)" );
+    params.time4   .name( "h2h (sec)" );
+    params.ref_time.name( "ref (sec)" );
+
+    params.gbytes    .name( "h2d GB/s" );
+    params.gbytes2   .name( "d2d GB/s" );
+    params.gbytes3   .name( "d2h GB/s" );
+    params.gbytes4   .name( "h2h GB/s" );
+    params.ref_gbytes.name( "ref GB/s" );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    enum class Method {
+        memcpy_2d,
+        copy_matrix,
+        set_matrix,
+    };
+
+    Method method;
+    if (params.routine == "memcpy_2d") {
+        method = Method::memcpy_2d;
+    }
+    else if (params.routine == "copy_matrix") {
+        method = Method::copy_matrix;
+    }
+    else if (params.routine == "set_matrix") {
+        method = Method::set_matrix;
+    }
+    else {
+        throw blas::Error( "unknown method" );
+    }
+
+    // setup
+    // Allocate extra to verify copy doesn't overrun buffer.
+    int64_t ld = roundup( m, align );
+    int64_t extra = 2;
+    int64_t size = ld*(n + extra);
+    T* a_host = new T[ size ];
+    T* b_host = new T[ size ];
+    T* c_host = new T[ size ];
+    T* d_host = new T[ size ];
+
+    // device specifics
+    blas::Queue queue( device, 0 );
+    T* b_dev = blas::device_malloc<T>( size, queue );
+    T* c_dev = blas::device_malloc<T>( size, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size, a_host );
+    lapack_larnv( idist, iseed, size, b_host );
+    lapack_larnv( idist, iseed, size, c_host );
+    lapack_larnv( idist, iseed, size, d_host );
+
+    // test error exits
+    assert_throw( blas::device_memcpy_2d( c_dev, m-1, b_dev, m,    m,  n, queue ), blas::Error );
+    assert_throw( blas::device_memcpy_2d( c_dev, m,   b_dev, m-1,  m,  n, queue ), blas::Error );
+    assert_throw( blas::device_memcpy_2d( c_dev, m,   b_dev, m,   -1,  n, queue ), blas::Error );
+    assert_throw( blas::device_memcpy_2d( c_dev, m,   b_dev, m,    m, -1, queue ), blas::Error );
+
+    assert_throw( blas::device_copy_matrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
+
+    assert_throw( blas::device_setmatrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_setmatrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_setmatrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_setmatrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
+
+    assert_throw( blas::device_getmatrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_getmatrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_getmatrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_getmatrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "m=%5lld, n=%5lld, ld=%2lld\n",
+                llong( m ), llong( n ), llong( ld ) );
+    }
+    if (verbose >= 2) {
+        printf( "a = " ); print_matrix( ld, n + extra, a_host, ld );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+
+    //----------
+    // a_host -> b_dev
+    double time = get_wtime();
+    if (method == Method::memcpy_2d) {
+        blas::device_memcpy_2d( b_dev, ld, a_host, ld, m, n, queue );
+    }
+    else if (method == Method::copy_matrix) {
+        blas::device_copy_matrix( m, n, a_host, ld, b_dev, ld, queue );
+    }
+    else if (method == Method::set_matrix) {
+        blas::device_setmatrix( m, n, a_host, ld, b_dev, ld, queue );
+    }
+    time = get_wtime() - time;
+
+    //----------
+    // b_dev -> c_dev
+    double time2 = get_wtime();
+    if (method == Method::copy_matrix) {
+        blas::device_copy_matrix( m, n, b_dev, ld, c_dev, ld, queue );
+    }
+    else {
+        // For method = memcpy_2d or set_matrix, use memcpy_2d.
+        blas::device_memcpy_2d( c_dev, ld, b_dev, ld, m, n, queue );
+    }
+    time2 = get_wtime() - time2;
+
+    //----------
+    // c_dev -> d_host
+    double time3 = get_wtime();
+    if (method == Method::memcpy_2d) {
+        blas::device_memcpy_2d( d_host, ld, c_dev, ld, m, n, queue );
+    }
+    else if (method == Method::copy_matrix) {
+        blas::device_copy_matrix( m, n, c_dev, ld, d_host, ld, queue );
+    }
+    else if (method == Method::set_matrix) {
+        blas::device_getmatrix( m, n, c_dev, ld, d_host, ld, queue );
+    }
+    time3 = get_wtime() - time3;
+
+    //----------
+    // a_host -> b_host
+    double time4 = get_wtime();
+    if (method == Method::copy_matrix) {
+        blas::device_copy_matrix( m, n, a_host, ld, b_host, ld, queue );
+    }
+    else {
+        // For method = memcpy_2d or set_matrix, use memcpy_2d.
+        blas::device_memcpy_2d( b_host, ld, a_host, ld, m, n, queue );
+    }
+    time4 = get_wtime() - time4;
+
+    //----------
+    // b_host -> c_host
+    double ref_time = get_wtime();
+    lapack_lacpy( "g", m, n, b_host, ld, c_host, ld );
+    ref_time = get_wtime() - ref_time;
+
+    // read m*n, write m*n
+    double gbyte = 2*m*n * 1e-9;
+
+    params.time()     = time;
+    params.time2()    = time2;
+    params.time3()    = time3;
+    params.time4()    = time4;
+    params.ref_time() = ref_time;
+
+    params.gbytes()     = gbyte / time;
+    params.gbytes2()    = gbyte / time2;
+    params.gbytes3()    = gbyte / time3;
+    params.gbytes4()    = gbyte / time4;
+    params.ref_gbytes() = gbyte / ref_time;
+
+    if (verbose >= 2) {
+        printf( "b = " ); print_matrix( ld, n + extra, b_host, ld );
+        printf( "c = " ); print_matrix( ld, n + extra, c_host, ld );
+        printf( "d = " ); print_matrix( ld, n + extra, d_host, ld );
+        printf( "Note last %lld rows and last %lld cols should NOT be copied!\n",
+                llong( ld - m ), llong( extra ) );
+    }
+
+    // check error
+    blas::axpy( size, -1.0, a_host, 1, b_host, 1 );
+    blas::axpy( size, -1.0, a_host, 1, c_host, 1 );
+    blas::axpy( size, -1.0, a_host, 1, d_host, 1 );
+    real_t dummy;
+    real_t error = lapack_lange( "m", m, n, b_host, ld, &dummy )
+                 + lapack_lange( "m", m, n, c_host, ld, &dummy )
+                 + lapack_lange( "m", m, n, d_host, ld, &dummy );
+    // Entries outside sub-matrix should NOT be copied.
+    // For first n cols, check i = m+1 : ld.
+    // For extra   cols, check i = 0   : ld.
+    for (int64_t j = 0; j < n + extra; ++j) {
+        for (int64_t i = (j < n ? m : 0); i < ld; ++i) {
+            if (a_host[ i + j*ld ] == b_host[ i + j*ld ])
+                error += 1;
+            if (a_host[ i + j*ld ] == c_host[ i + j*ld ])
+                error += 1;
+            if (a_host[ i + j*ld ] == d_host[ i + j*ld ])
+                error += 1;
+        }
+    }
+    params.error() = error;
+    params.okay() = (error == 0);  // copy must be exact
+
+    delete[] a_host;
+    delete[] b_host;
+    delete[] c_host;
+    delete[] d_host;
+    blas::device_free( b_dev, queue );
+    blas::device_free( c_dev, queue );
+}
+
+// -----------------------------------------------------------------------------
+void test_memcpy_2d( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_memcpy_2d_work< float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_memcpy_2d_work< double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_memcpy_2d_work< std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_memcpy_2d_work< std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}


### PR DESCRIPTION
* Refactor memcpy, memcpy_2d to support copying in any direction (host to device, device to device, device to host, host to host).
* Refactor set/getvector, set/getmatrix to use memcpy(_2d).
* Adds copy_vector, copy_matrix to support copy in any direction.
* Add memcpy, memcpy_2d testers.
* Tested on CUDA, ROCm, oneMKL.
