### PR TITLE
Host malloc

### DIFF
--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -117,7 +117,10 @@ void enumerate_devices(std::vector<cl::sycl::device> &devices)
 #endif
 
 // -----------------------------------------------------------------------------
-/// free a device pointer
+/// @deprecated: use device_free( ptr, queue ).
+/// Free a device memory space on the current device,
+/// allocated with device_malloc.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void device_free( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -138,7 +141,8 @@ void device_free( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a device pointer for a given device
+/// Free a device memory space, allocated with device_malloc,
+/// on the queue's device.
 void device_free( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -152,14 +156,16 @@ void device_free( void* ptr, blas::Queue &queue )
             hipFree( ptr ) );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-       blas_dev_call(
-           sycl::free( ptr, queue.stream() ) );
+        blas_dev_call(
+            sycl::free( ptr, queue.stream() ) );
     #endif
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr )
+/// @deprecated: use host_free_pinned( ptr, queue ).
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
+void host_free_pinned( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(
@@ -178,8 +184,8 @@ void device_free_pinned( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr,  blas::Queue &queue )
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+void host_free_pinned( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -10,7 +10,9 @@
 namespace blas {
 
 // -----------------------------------------------------------------------------
-// set device
+/// @deprecated
+/// Set current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void set_device( blas::Device device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -30,7 +32,9 @@ void set_device( blas::Device device )
 }
 
 // -----------------------------------------------------------------------------
-// get current device
+/// @deprecated
+/// Get current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void get_device( blas::Device *device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -54,7 +58,7 @@ void get_device( blas::Device *device )
 }
 
 // -----------------------------------------------------------------------------
-// @return number of GPU devices
+/// @return number of GPU devices.
 device_blas_int get_device_count()
 {
     device_blas_int dev_count = 0;
@@ -70,13 +74,13 @@ device_blas_int get_device_count()
             blas_dev_call( err );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-    auto platforms = sycl::platform::get_platforms();
-    for (auto &platform : platforms) {
-        auto devices = platform.get_devices();
-        for (auto &device : devices ) {
-            dev_count += device.is_gpu();
+        auto platforms = sycl::platform::get_platforms();
+        for (auto &platform : platforms) {
+            auto devices = platform.get_devices();
+            for (auto &device : devices ) {
+                dev_count += device.is_gpu();
+            }
         }
-    }
 
     #else
         // return dev_count = 0
@@ -86,13 +90,13 @@ device_blas_int get_device_count()
 }
 
 // -----------------------------------------------------------------------------
-// @return a vector of sycl gpu devices
+/// @return vector of SYCL GPU devices.
 #ifdef BLAS_HAVE_ONEMKL
 void enumerate_devices(std::vector<cl::sycl::device> &devices)
 {
     device_blas_int dev_count = get_device_count();
 
-    if(devices.size() != (size_t)dev_count) {
+    if (devices.size() != (size_t)dev_count) {
         devices.clear();
         devices.reserve( dev_count );
     }

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -88,10 +88,10 @@ void test_memcpy_work( Params& params, bool run )
     int64_t inc = std::max( inc_ac, inc_bd );
     int64_t extra = 2;
     int64_t size = inc*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -259,10 +259,10 @@ void test_memcpy_work( Params& params, bool run )
     if (verbose >= 1)
         printf( "cleanup\n" );
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -80,10 +80,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     int64_t ld = roundup( m, align );
     int64_t extra = 2;
     int64_t size = ld*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -234,10 +234,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     params.error() = error;
     params.okay() = (error == 0);  // copy must be exact
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }


### PR DESCRIPTION
* Rename device_malloc_pinned to host_malloc_pinned, since it is host memory.
* Deprecate old routines in Doxygen. We will do C++ deprecation once SLATE is updated.
* Update docs and clean code a bit.

This PR comes after the `memcpy` PR.