### PR TITLE
Style

### DIFF
--- a/include/blas/asum.hh
+++ b/include/blas/asum.hh
@@ -30,7 +30,7 @@ namespace blas {
 ///
 /// @ingroup asum
 
-template< typename T >
+template <typename T>
 real_type<T>
 asum(
     int64_t n,

--- a/include/blas/axpy.hh
+++ b/include/blas/axpy.hh
@@ -39,7 +39,7 @@ namespace blas {
 ///
 /// @ingroup axpy
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void axpy(
     int64_t n,
     blas::scalar_type<TX, TY> alpha,

--- a/include/blas/batch_common.hh
+++ b/include/blas/batch_common.hh
@@ -196,10 +196,10 @@ void trsm_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Side  side_ = extract<Side>(side , i);
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op  >(trans, i);
-        Diag  diag_ = extract<Diag>(diag , i);
+        Side  side_ = extract<Side>( side,  i );
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op  >( trans, i );
+        Diag  diag_ = extract<Diag>( diag,  i );
 
         int64_t m_ = extract<int64_t>(m, i);
         int64_t n_ = extract<int64_t>(n, i);
@@ -311,10 +311,10 @@ void trmm_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Side  side_ = extract<Side>(side , i);
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op  >(trans, i);
-        Diag  diag_ = extract<Diag>(diag , i);
+        Side  side_ = extract<Side>( side,  i );
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op  >( trans, i );
+        Diag  diag_ = extract<Diag>( diag,  i );
 
         int64_t m_ = extract<int64_t>(m, i);
         int64_t n_ = extract<int64_t>(n, i);
@@ -441,8 +441,8 @@ void hemm_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Side  side_ = extract<Side>(side , i);
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
+        Side  side_ = extract<Side>( side, i );
+        Uplo  uplo_ = extract<Uplo>( uplo, i );
 
         int64_t m_ = extract<int64_t>(m, i);
         int64_t n_ = extract<int64_t>(n, i);
@@ -556,8 +556,8 @@ void herk_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op>(trans , i);
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op>  ( trans, i );
 
         int64_t n_ = extract<int64_t>(n, i);
         int64_t k_ = extract<int64_t>(k, i);
@@ -686,8 +686,8 @@ void syrk_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op>(trans , i);
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op>  ( trans, i );
 
         int64_t n_ = extract<int64_t>(n, i);
         int64_t k_ = extract<int64_t>(k, i);
@@ -808,8 +808,8 @@ void her2k_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op>(trans , i);
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op>  ( trans, i );
 
         int64_t n_ = extract<int64_t>(n, i);
         int64_t k_ = extract<int64_t>(k, i);
@@ -933,8 +933,8 @@ void syr2k_check(
 
     #pragma omp parallel for schedule(dynamic)
     for (size_t i = 0; i < batchCount; ++i) {
-        Uplo  uplo_ = extract<Uplo>(uplo , i);
-        Op   trans_ = extract<Op>(trans , i);
+        Uplo  uplo_ = extract<Uplo>( uplo,  i );
+        Op   trans_ = extract<Op>  ( trans, i );
 
         int64_t n_ = extract<int64_t>(n, i);
         int64_t k_ = extract<int64_t>(k, i);

--- a/include/blas/batch_common.hh
+++ b/include/blas/batch_common.hh
@@ -15,7 +15,7 @@ namespace batch {
 
 #define INTERNAL_INFO_DEFAULT    (-1000)
 
-template<typename T>
+template <typename T>
 T extract(std::vector<T> const &ivector, const int64_t index)
 {
     return (ivector.size() == 1) ? ivector[0] : ivector[index];
@@ -23,7 +23,7 @@ T extract(std::vector<T> const &ivector, const int64_t index)
 
 // -----------------------------------------------------------------------------
 // batch gemm check
-template<typename T>
+template <typename T>
 void gemm_check(
         blas::Layout                 layout,
         std::vector<blas::Op> const &transA,
@@ -143,7 +143,7 @@ void gemm_check(
 
 // -----------------------------------------------------------------------------
 // batch trsm check
-template<typename T>
+template <typename T>
 void trsm_check(
         blas::Layout                   layout,
         std::vector<blas::Side> const &side,
@@ -258,7 +258,7 @@ void trsm_check(
 
 // -----------------------------------------------------------------------------
 // batch trmm check
-template<typename T>
+template <typename T>
 void trmm_check(
         blas::Layout                   layout,
         std::vector<blas::Side> const &side,
@@ -373,7 +373,7 @@ void trmm_check(
 
 // -----------------------------------------------------------------------------
 // batch hemm check
-template<typename T>
+template <typename T>
 void hemm_check(
         blas::Layout                   layout,
         std::vector<blas::Side> const &side,
@@ -498,7 +498,7 @@ void hemm_check(
 
 // -----------------------------------------------------------------------------
 // batch herk check
-template<typename T, typename scalarT>
+template <typename T, typename scalarT>
 void herk_check(
         blas::Layout                   layout,
         std::vector<blas::Uplo> const &uplo,
@@ -609,7 +609,7 @@ void herk_check(
 
 // -----------------------------------------------------------------------------
 // batch hemm check
-template<typename T>
+template <typename T>
 void symm_check(
         blas::Layout                   layout,
         std::vector<blas::Side> const &side,
@@ -628,7 +628,7 @@ void symm_check(
 
 // -----------------------------------------------------------------------------
 // batch syrk check
-template<typename T>
+template <typename T>
 void syrk_check(
         blas::Layout                   layout,
         std::vector<blas::Uplo> const &uplo,
@@ -739,7 +739,7 @@ void syrk_check(
 
 // -----------------------------------------------------------------------------
 // batch her2k check
-template<typename T, typename scalarT>
+template <typename T, typename scalarT>
 void her2k_check(
         blas::Layout                   layout,
         std::vector<blas::Uplo> const &uplo,
@@ -864,7 +864,7 @@ void her2k_check(
 
 // -----------------------------------------------------------------------------
 // batch syr2k check
-template<typename T>
+template <typename T>
 void syr2k_check(
         blas::Layout                   layout,
         std::vector<blas::Uplo> const &uplo,

--- a/include/blas/copy.hh
+++ b/include/blas/copy.hh
@@ -36,7 +36,7 @@ namespace blas {
 ///
 /// @ingroup copy
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void copy(
     int64_t n,
     TX const *x, int64_t incx,

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -304,60 +304,65 @@ inline const char* device_error_string( rocblas_status error )
 
     // blaspp aborts on device errors
     #if defined(BLAS_HAVE_ONEMKL)
-    #define blas_dev_call( error ) \
-        try { \
-            error; \
-        } \
-        catch (cl::sycl::exception const& e) { \
-            blas::internal::abort_if( true, __func__, \
-                                      "%s", e.what() ); \
-        } \
-        catch (std::exception const& e) { \
-            blas::internal::abort_if( true, __func__, \
-                                      "%s", e.what() ); \
-        } \
-        catch (...) { \
-            blas::internal::abort_if( true, __func__, \
-                                      "%s", "unknown exception" ); \
-        }
+        #define blas_dev_call( error ) \
+            do {
+                try { \
+                    error; \
+                } \
+                catch (cl::sycl::exception const& e) { \
+                    blas::internal::abort_if( true, __func__, \
+                                              "%s", e.what() ); \
+                } \
+                catch (std::exception const& e) { \
+                    blas::internal::abort_if( true, __func__, \
+                                              "%s", e.what() ); \
+                } \
+                catch (...) { \
+                    blas::internal::abort_if( true, __func__, \
+                                              "%s", "unknown exception" ); \
+                }
+            } while(0)
 
     #else
-    #define blas_dev_call( error ) \
-        do { \
-            auto e = error; \
-            blas::internal::abort_if( blas::is_device_error(e), __func__, \
-                                      "%s", blas::device_error_string(e) ); \
-        } while(0)
+        #define blas_dev_call( error ) \
+            do { \
+                auto e = error; \
+                blas::internal::abort_if( blas::is_device_error(e), __func__, \
+                                          "%s", blas::device_error_string(e) ); \
+            } while(0)
     #endif
 
 #else
 
     // blaspp throws device errors (default)
     #if defined(BLAS_HAVE_ONEMKL)
-    #define blas_dev_call( error ) \
-        try { \
-                error; \
-        } \
-        catch (cl::sycl::exception const& e) { \
-            blas::internal::throw_if( true, \
-                                      e.what(), __func__ ); \
-        } \
-        catch (std::exception const& e) { \
-            blas::internal::throw_if( true, \
-                                      e.what(), __func__ ); \
-        } \
-        catch (...) { \
-            blas::internal::throw_if( true, \
-                                      "unknown exception", __func__ ); \
-        }
+        #define blas_dev_call( error ) \
+            do {
+                try { \
+                        error; \
+                } \
+                catch (cl::sycl::exception const& e) { \
+                    blas::internal::throw_if( true, \
+                                              e.what(), __func__ ); \
+                } \
+                catch (std::exception const& e) { \
+                    blas::internal::throw_if( true, \
+                                              e.what(), __func__ ); \
+                } \
+                catch (...) { \
+                    blas::internal::throw_if( true, \
+                                              "unknown exception", __func__ ); \
+                }
+            } while(0)
 
     #else
-    #define blas_dev_call( error ) \
-        do { \
-            auto e = error; \
-            blas::internal::throw_if( blas::is_device_error(e), \
-                                      blas::device_error_string(e), __func__ ); \
-        } while(0)
+        #define blas_dev_call( error ) \
+            do { \
+                auto e = error; \
+                blas::internal::throw_if( blas::is_device_error(e), \
+                                          blas::device_error_string(e), \
+                                          __func__ ); \
+            } while(0)
     #endif
 
 #endif

--- a/include/blas/dot.hh
+++ b/include/blas/dot.hh
@@ -37,7 +37,7 @@ namespace blas {
 ///
 /// @ingroup dot
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 scalar_type<TX, TY> dot(
     int64_t n,
     TX const *x, int64_t incx,

--- a/include/blas/dotu.hh
+++ b/include/blas/dotu.hh
@@ -37,7 +37,7 @@ namespace blas {
 ///
 /// @ingroup dotu
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 scalar_type<TX, TY> dotu(
     int64_t n,
     TX const *x, int64_t incx,

--- a/include/blas/flops.hh
+++ b/include/blas/flops.hh
@@ -160,7 +160,7 @@ inline double fadds_trmm( blas::Side side, double m, double n )
 // gflop< float >::gemm( m, n, k ) yields flops for sgemm.
 // gflop< std::complex<float> >::gemm( m, n, k ) yields flops for cgemm.
 //==============================================================================
-template< typename T >
+template <typename T>
 class Gbyte
 {
 public:
@@ -315,7 +315,7 @@ public:
 // gflop< float >::gemm( m, n, k ) yields flops for sgemm.
 // gflop< std::complex<float> >::gemm( m, n, k ) yields flops for cgemm.
 //==============================================================================
-template< typename T >
+template <typename T>
 class Gflop
 {
 public:

--- a/include/blas/gemm.hh
+++ b/include/blas/gemm.hh
@@ -86,7 +86,7 @@ namespace blas {
 ///
 /// @ingroup gemm
 
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void gemm(
     blas::Layout layout,
     blas::Op transA,

--- a/include/blas/gemv.hh
+++ b/include/blas/gemv.hh
@@ -75,7 +75,7 @@ namespace blas {
 ///
 /// @ingroup gemv
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void gemv(
     blas::Layout layout,
     blas::Op trans,

--- a/include/blas/ger.hh
+++ b/include/blas/ger.hh
@@ -56,7 +56,7 @@ namespace blas {
 ///
 /// @ingroup ger
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void ger(
     blas::Layout layout,
     int64_t m, int64_t n,

--- a/include/blas/geru.hh
+++ b/include/blas/geru.hh
@@ -57,7 +57,7 @@ namespace blas {
 ///
 /// @ingroup geru
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void geru(
     blas::Layout layout,
     int64_t m, int64_t n,

--- a/include/blas/hemm.hh
+++ b/include/blas/hemm.hh
@@ -81,7 +81,7 @@ namespace blas {
 ///
 /// @ingroup hemm
 
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void hemm(
     blas::Layout layout,
     blas::Side side,

--- a/include/blas/hemv.hh
+++ b/include/blas/hemv.hh
@@ -65,7 +65,7 @@ namespace blas {
 ///
 /// @ingroup hemv
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void hemv(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/her.hh
+++ b/include/blas/her.hh
@@ -55,7 +55,7 @@ namespace blas {
 ///
 /// @ingroup her
 
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void her(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/her2.hh
+++ b/include/blas/her2.hh
@@ -62,7 +62,7 @@ namespace blas {
 ///
 /// @ingroup her2
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void her2(
     blas::Layout layout,
     blas::Uplo  uplo,

--- a/include/blas/her2k.hh
+++ b/include/blas/her2k.hh
@@ -87,7 +87,7 @@ namespace blas {
 ///
 /// @ingroup her2k
 
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/herk.hh
+++ b/include/blas/herk.hh
@@ -76,7 +76,7 @@ namespace blas {
 ///
 /// @ingroup herk
 
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void herk(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/iamax.hh
+++ b/include/blas/iamax.hh
@@ -30,7 +30,7 @@ namespace blas {
 ///
 /// @ingroup iamax
 
-template< typename T >
+template <typename T>
 int64_t iamax(
     int64_t n,
     T const *x, int64_t incx )

--- a/include/blas/nrm2.hh
+++ b/include/blas/nrm2.hh
@@ -30,7 +30,7 @@ namespace blas {
 ///
 /// @ingroup nrm2
 
-template< typename T >
+template <typename T>
 real_type<T>
 nrm2(
     int64_t n,

--- a/include/blas/rot.hh
+++ b/include/blas/rot.hh
@@ -49,7 +49,7 @@ namespace blas {
 ///
 /// @ingroup rot
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void rot(
     int64_t n,
     TX *x, int64_t incx,

--- a/include/blas/rotg.hh
+++ b/include/blas/rotg.hh
@@ -126,7 +126,7 @@ void rotg(
 ///
 /// @ingroup rotg
 
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void rotg(
     std::complex<TA> *a,
     std::complex<TB> *b,

--- a/include/blas/rotm.hh
+++ b/include/blas/rotm.hh
@@ -46,7 +46,7 @@ namespace blas {
 ///
 /// @ingroup rotm
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void rotm(
     int64_t n,
     TX *x, int64_t incx,

--- a/include/blas/rotmg.hh
+++ b/include/blas/rotmg.hh
@@ -95,7 +95,7 @@ namespace blas {
 ///
 /// @ingroup rotmg
 
-template< typename T >
+template <typename T>
 void rotmg(
     T *d1,
     T *d2,

--- a/include/blas/scal.hh
+++ b/include/blas/scal.hh
@@ -31,7 +31,7 @@ namespace blas {
 ///
 /// @ingroup scal
 
-template< typename T >
+template <typename T>
 void scal(
     int64_t n,
     T alpha,

--- a/include/blas/swap.hh
+++ b/include/blas/swap.hh
@@ -36,7 +36,7 @@ namespace blas {
 ///
 /// @ingroup swap
 
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void swap(
     int64_t n,
     TX *x, int64_t incx,

--- a/include/blas/symm.hh
+++ b/include/blas/symm.hh
@@ -74,7 +74,7 @@ namespace blas {
 ///
 /// @ingroup symm
 
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void symm(
     blas::Layout layout,
     blas::Side side,

--- a/include/blas/symv.hh
+++ b/include/blas/symv.hh
@@ -62,7 +62,7 @@ namespace blas {
 ///
 /// @ingroup symv
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/syr.hh
+++ b/include/blas/syr.hh
@@ -52,7 +52,7 @@ namespace blas {
 ///
 /// @ingroup syr
 
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void syr(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/syr2.hh
+++ b/include/blas/syr2.hh
@@ -59,7 +59,7 @@ namespace blas {
 ///
 /// @ingroup syr2
 
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void syr2(
     blas::Layout layout,
     blas::Uplo  uplo,

--- a/include/blas/syr2k.hh
+++ b/include/blas/syr2k.hh
@@ -86,7 +86,7 @@ namespace blas {
 ///
 /// @ingroup syr2k
 
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/syrk.hh
+++ b/include/blas/syrk.hh
@@ -75,7 +75,7 @@ namespace blas {
 ///
 /// @ingroup syrk
 
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void syrk(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/trmm.hh
+++ b/include/blas/trmm.hh
@@ -84,7 +84,7 @@ namespace blas {
 ///
 /// @ingroup trmm
 
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void trmm(
     blas::Layout layout,
     blas::Side side,

--- a/include/blas/trmv.hh
+++ b/include/blas/trmv.hh
@@ -65,7 +65,7 @@ namespace blas {
 ///
 /// @ingroup trmv
 
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void trmv(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/trsm.hh
+++ b/include/blas/trsm.hh
@@ -89,7 +89,7 @@ namespace blas {
 ///
 /// @ingroup trsm
 
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void trsm(
     blas::Layout layout,
     blas::Side side,

--- a/include/blas/trsv.hh
+++ b/include/blas/trsv.hh
@@ -69,7 +69,7 @@ namespace blas {
 ///
 /// @ingroup trsv
 
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void trsv(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -174,13 +174,13 @@ private:
 
 // -----------------------------------------------------------------------------
 // 1-norm absolute value, |Re(x)| + |Im(x)|
-template< typename T >
+template <typename T>
 T abs1( T x )
 {
     return std::abs( x );
 }
 
-template< typename T >
+template <typename T>
 T abs1( std::complex<T> x )
 {
     return std::abs( real(x) ) + std::abs( imag(x) );
@@ -192,10 +192,10 @@ T abs1( std::complex<T> x )
     using std::common_type_t;
     using std::decay_t;
 #else
-    template< typename... Ts >
+    template <typename... Ts>
     using common_type_t = typename std::common_type< Ts... >::type;
 
-    template< typename... Ts >
+    template <typename... Ts>
     using decay_t = typename std::decay< Ts... >::type;
 #endif
 
@@ -228,7 +228,7 @@ using std::imag;
 /// That will use std::conj for complex types, and blas::conj for other types.
 /// This prohibits complex types; it can't be called as y = blas::conj( x ).
 ///
-template< typename T >
+template <typename T>
 inline T conj( T x )
 {
     static_assert(
@@ -250,15 +250,15 @@ inline T conj( T x )
 //        scalar_type< int, complex<long> > is complex<long> (right)
 
 // for zero types
-template< typename... Types >
+template <typename... Types>
 struct scalar_type_traits;
 
 // define scalar_type<> type alias
-template< typename... Types >
+template <typename... Types>
 using scalar_type = typename scalar_type_traits< Types... >::type;
 
 // for one type
-template< typename T >
+template <typename T>
 struct scalar_type_traits< T >
 {
     using type = decay_t<T>;
@@ -266,7 +266,7 @@ struct scalar_type_traits< T >
 
 // for two types
 // relies on type of ?: operator being the common type of its two arguments
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 struct scalar_type_traits< T1, T2 >
 {
     using type = decay_t< decltype( true ? std::declval<T1>() : std::declval<T2>() ) >;
@@ -274,26 +274,26 @@ struct scalar_type_traits< T1, T2 >
 
 // for either or both complex,
 // find common type of associated real types, then add complex
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 struct scalar_type_traits< std::complex<T1>, T2 >
 {
     using type = std::complex< common_type_t< T1, T2 > >;
 };
 
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 struct scalar_type_traits< T1, std::complex<T2> >
 {
     using type = std::complex< common_type_t< T1, T2 > >;
 };
 
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 struct scalar_type_traits< std::complex<T1>, std::complex<T2> >
 {
     using type = std::complex< common_type_t< T1, T2 > >;
 };
 
 // for three or more types
-template< typename T1, typename T2, typename... Types >
+template <typename T1, typename T2, typename... Types>
 struct scalar_type_traits< T1, T2, Types... >
 {
     using type = scalar_type< scalar_type< T1, T2 >, Types... >;
@@ -315,33 +315,33 @@ struct scalar_type_traits< T1, T2, Types... >
 // complex_type< float, double, complex<float> >    is complex<double>
 
 // for zero types
-template< typename... Types >
+template <typename... Types>
 struct real_type_traits;
 
 // define real_type<> type alias
-template< typename... Types >
+template <typename... Types>
 using real_type = typename real_type_traits< Types... >::real_t;
 
 // define complex_type<> type alias
-template< typename... Types >
+template <typename... Types>
 using complex_type = std::complex< real_type< Types... > >;
 
 // for one type
-template< typename T >
+template <typename T>
 struct real_type_traits<T>
 {
     using real_t = T;
 };
 
 // for one complex type, strip complex
-template< typename T >
+template <typename T>
 struct real_type_traits< std::complex<T> >
 {
     using real_t = T;
 };
 
 // for two or more types
-template< typename T1, typename... Types >
+template <typename T1, typename... Types>
 struct real_type_traits< T1, Types... >
 {
     using real_t = scalar_type< real_type<T1>, real_type< Types... > >;
@@ -352,14 +352,14 @@ struct real_type_traits< T1, Types... >
 // and any number of arguments: max( a, b, c, d )
 
 // one argument
-template< typename T >
+template <typename T>
 T max( T x )
 {
     return x;
 }
 
 // two arguments
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 scalar_type< T1, T2 >
     max( T1 x, T2 y )
 {
@@ -367,7 +367,7 @@ scalar_type< T1, T2 >
 }
 
 // three or more arguments
-template< typename T1, typename... Types >
+template <typename T1, typename... Types>
 scalar_type< T1, Types... >
     max( T1 first, Types... args )
 {
@@ -379,14 +379,14 @@ scalar_type< T1, Types... >
 // and any number of arguments: min( a, b, c, d )
 
 // one argument
-template< typename T >
+template <typename T>
 T min( T x )
 {
     return x;
 }
 
 // two arguments
-template< typename T1, typename T2 >
+template <typename T1, typename T2>
 scalar_type< T1, T2 >
     min( T1 x, T2 y )
 {
@@ -394,7 +394,7 @@ scalar_type< T1, T2 >
 }
 
 // three or more arguments
-template< typename T1, typename... Types >
+template <typename T1, typename... Types>
 scalar_type< T1, Types... >
     min( T1 first, Types... args )
 {

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -19,6 +19,11 @@ namespace blas {
 /// Use to silence compiler warning of unused variable.
 #define blas_unused( var ) ((void)var)
 
+// For printf, int64_t could be long (%ld), which is >= 32 bits,
+// or long long (%lld), guaranteed >= 64 bits.
+// Cast to llong to ensure printing 64 bits.
+using llong = long long;
+
 // -----------------------------------------------------------------------------
 enum class Layout : char { ColMajor = 'C', RowMajor = 'R' };
 enum class Op     : char { NoTrans  = 'N', Trans    = 'T', ConjTrans = 'C' };

--- a/src/batch_gemm.cc
+++ b/src/batch_gemm.cc
@@ -25,7 +25,7 @@ void blas::batch::gemm(
     const size_t batch,                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::gemm_check<float>( layout, transA, transB,
@@ -69,15 +69,15 @@ void blas::batch::gemm(
     std::vector<int64_t>  const &n,
     std::vector<int64_t>  const &k,
     std::vector<double >  const &alpha,
-    std::vector<double*>  const &Aarray, std::vector<int64_t>  const &ldda,
-    std::vector<double*>  const &Barray, std::vector<int64_t>  const &lddb,
+    std::vector<double*>  const &Aarray, std::vector<int64_t> const &ldda,
+    std::vector<double*>  const &Barray, std::vector<int64_t> const &lddb,
     std::vector<double >  const &beta,
     std::vector<double*>  const &Carray, std::vector<int64_t> const &lddc,
     const size_t batch,                  std::vector<int64_t>       &info )
 {
 
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::gemm_check<double>( layout, transA, transB,
@@ -120,16 +120,16 @@ void blas::batch::gemm(
     std::vector<int64_t>  const &m,
     std::vector<int64_t>  const &n,
     std::vector<int64_t>  const &k,
-    std::vector< std::complex<float>  >   const &alpha,
-    std::vector< std::complex<float>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<float>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<float>  >   const &beta,
-    std::vector< std::complex<float>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>  &info )
+    std::vector< std::complex<float>  > const &alpha,
+    std::vector< std::complex<float>* > const &Aarray, std::vector<int64_t> const &ldda,
+    std::vector< std::complex<float>* > const &Barray, std::vector<int64_t> const &lddb,
+    std::vector< std::complex<float>  > const &beta,
+    std::vector< std::complex<float>* > const &Carray, std::vector<int64_t> const &lddc,
+    const size_t batch,                                std::vector<int64_t> &info )
 {
 
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::gemm_check< std::complex<float> >( layout, transA, transB,
@@ -172,16 +172,16 @@ void blas::batch::gemm(
     std::vector<int64_t>  const &m,
     std::vector<int64_t>  const &n,
     std::vector<int64_t>  const &k,
-    std::vector< std::complex<double>  >   const &alpha,
-    std::vector< std::complex<double>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<double>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<double>  >   const &beta,
-    std::vector< std::complex<double>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+    std::vector< std::complex<double>  > const &alpha,
+    std::vector< std::complex<double>* > const &Aarray, std::vector<int64_t> const &ldda,
+    std::vector< std::complex<double>* > const &Barray, std::vector<int64_t> const &lddb,
+    std::vector< std::complex<double>  > const &beta,
+    std::vector< std::complex<double>* > const &Carray, std::vector<int64_t> const &lddc,
+    const size_t batch,                                 std::vector<int64_t>       &info )
 {
 
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::gemm_check< std::complex<double> >( layout, transA, transB,

--- a/src/batch_hemm.cc
+++ b/src/batch_hemm.cc
@@ -152,8 +152,8 @@ void blas::batch::hemm(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::hemm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -202,8 +202,8 @@ void blas::batch::hemm(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::hemm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_hemm.cc
+++ b/src/batch_hemm.cc
@@ -24,7 +24,7 @@ void blas::batch::hemm(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<float>(
@@ -74,7 +74,7 @@ void blas::batch::hemm(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<double>(
@@ -124,7 +124,7 @@ void blas::batch::hemm(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<std::complex<float>>(
@@ -174,7 +174,7 @@ void blas::batch::hemm(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<std::complex<double>>(

--- a/src/batch_her2k.cc
+++ b/src/batch_her2k.cc
@@ -52,8 +52,8 @@ void blas::batch::her2k(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -102,8 +102,8 @@ void blas::batch::her2k(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -152,8 +152,8 @@ void blas::batch::her2k(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -202,8 +202,8 @@ void blas::batch::her2k(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_her2k.cc
+++ b/src/batch_her2k.cc
@@ -24,7 +24,7 @@ void blas::batch::her2k(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<float, float>(
@@ -74,7 +74,7 @@ void blas::batch::her2k(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<double, double>(
@@ -124,7 +124,7 @@ void blas::batch::her2k(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<std::complex<float>, float>(
@@ -174,7 +174,7 @@ void blas::batch::her2k(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<std::complex<double>, double>(

--- a/src/batch_herk.cc
+++ b/src/batch_herk.cc
@@ -48,7 +48,7 @@ void blas::batch::herk(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -93,7 +93,7 @@ void blas::batch::herk(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -138,7 +138,7 @@ void blas::batch::herk(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -183,7 +183,7 @@ void blas::batch::herk(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_herk.cc
+++ b/src/batch_herk.cc
@@ -23,7 +23,7 @@ void blas::batch::herk(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<float, float>(
@@ -68,7 +68,7 @@ void blas::batch::herk(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<double, double>(
@@ -113,7 +113,7 @@ void blas::batch::herk(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<std::complex<float>, float>(
@@ -158,7 +158,7 @@ void blas::batch::herk(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<std::complex<double>, double>(

--- a/src/batch_symm.cc
+++ b/src/batch_symm.cc
@@ -52,8 +52,8 @@ void blas::batch::symm(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -102,8 +102,8 @@ void blas::batch::symm(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -152,8 +152,8 @@ void blas::batch::symm(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -202,8 +202,8 @@ void blas::batch::symm(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_symm.cc
+++ b/src/batch_symm.cc
@@ -24,7 +24,7 @@ void blas::batch::symm(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<float>(
@@ -74,7 +74,7 @@ void blas::batch::symm(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<double>(
@@ -124,7 +124,7 @@ void blas::batch::symm(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<std::complex<float>>(
@@ -174,7 +174,7 @@ void blas::batch::symm(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<std::complex<double>>(

--- a/src/batch_syr2k.cc
+++ b/src/batch_syr2k.cc
@@ -52,8 +52,8 @@ void blas::batch::syr2k(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -102,8 +102,8 @@ void blas::batch::syr2k(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -152,8 +152,8 @@ void blas::batch::syr2k(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -202,8 +202,8 @@ void blas::batch::syr2k(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_syr2k.cc
+++ b/src/batch_syr2k.cc
@@ -24,7 +24,7 @@ void blas::batch::syr2k(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<float>(
@@ -74,7 +74,7 @@ void blas::batch::syr2k(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<double>(
@@ -124,7 +124,7 @@ void blas::batch::syr2k(
     const size_t batch,                              std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<std::complex<float>>(
@@ -174,7 +174,7 @@ void blas::batch::syr2k(
     const size_t batch,                               std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<std::complex<double>>(

--- a/src/batch_syrk.cc
+++ b/src/batch_syrk.cc
@@ -23,7 +23,7 @@ void blas::batch::syrk(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<float>(
@@ -68,7 +68,7 @@ void blas::batch::syrk(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<double>(
@@ -113,7 +113,7 @@ void blas::batch::syrk(
     const size_t batch,                              std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<std::complex<float>>(
@@ -158,7 +158,7 @@ void blas::batch::syrk(
     const size_t batch,                               std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<std::complex<double>>(

--- a/src/batch_syrk.cc
+++ b/src/batch_syrk.cc
@@ -48,7 +48,7 @@ void blas::batch::syrk(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -93,7 +93,7 @@ void blas::batch::syrk(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -138,7 +138,7 @@ void blas::batch::syrk(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }
@@ -183,7 +183,7 @@ void blas::batch::syrk(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
+            alpha_, dA_, lda_,
             beta_,  dC_, ldc_ );
     }
 }

--- a/src/batch_trmm.cc
+++ b/src/batch_trmm.cc
@@ -24,7 +24,7 @@ void blas::batch::trmm(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<float>( layout, side, uplo, trans, diag,
@@ -71,7 +71,7 @@ void blas::batch::trmm(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<double>( layout, side, uplo, trans, diag,
@@ -118,7 +118,7 @@ void blas::batch::trmm(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<std::complex<float>>(
@@ -165,7 +165,7 @@ void blas::batch::trmm(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<std::complex<double>>(

--- a/src/batch_trsm.cc
+++ b/src/batch_trsm.cc
@@ -24,7 +24,7 @@ void blas::batch::trsm(
     const size_t batch,                    std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<float>( layout, side, uplo, trans, diag,
@@ -71,7 +71,7 @@ void blas::batch::trsm(
     const size_t batch,                     std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<double>( layout, side, uplo, trans, diag,
@@ -118,7 +118,7 @@ void blas::batch::trsm(
     const size_t batch,                                  std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<std::complex<float>>(
@@ -166,7 +166,7 @@ void blas::batch::trsm(
     const size_t batch,                                   std::vector<int64_t>       &info )
 {
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<std::complex<double>>(

--- a/src/device_batch_gemm.cc
+++ b/src/device_batch_gemm.cc
@@ -11,9 +11,12 @@
 #include <limits>
 #include <cstring>
 
+namespace blas {
+namespace batch {
+
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -28,17 +31,19 @@ void blas::batch::gemm(
     const size_t batch,                  std::vector<int64_t>       &info,
     blas::Queue &queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
+    blas_error_if( layout != Layout::ColMajor
+                && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<float>( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
+        gemm_check<float>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            batch, info );
     }
 
     bool fixed_size =   ( transA.size() == 1     &&
@@ -71,7 +76,7 @@ void blas::batch::gemm(
 
         size_t batch_limit = queue.get_batch_limit();
         float **dAarray, **dBarray, **dCarray;
-        dAarray = (float**)queue.get_dev_ptr_array();
+        dAarray = (float**) queue.get_dev_ptr_array();
         dBarray = dAarray + batch_limit;
         dCarray = dBarray + batch_limit;
 
@@ -79,9 +84,12 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<float*>(ibatch, (float**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector<float*>(ibatch, (float**)&Barray[ib], 1, dBarray, 1, queue);
-            device_setvector<float*>(ibatch, (float**)&Carray[ib], 1, dCarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Aarray[ib], 1, dAarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Barray[ib], 1, dBarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Carray[ib], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -131,7 +139,7 @@ void blas::batch::gemm(
 
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -148,15 +156,16 @@ void blas::batch::gemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<double>( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
+        gemm_check<double>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            batch, info );
     }
     bool fixed_size =   ( transA.size() == 1     &&
                           transB.size() == 1     &&
@@ -188,7 +197,7 @@ void blas::batch::gemm(
 
         size_t batch_limit = queue.get_batch_limit();
         double **dAarray, **dBarray, **dCarray;
-        dAarray = (double**)queue.get_dev_ptr_array();
+        dAarray = (double**) queue.get_dev_ptr_array();
         dBarray = dAarray + batch_limit;
         dCarray = dBarray + batch_limit;
 
@@ -196,9 +205,12 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<double*>(ibatch, (double**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector<double*>(ibatch, (double**)&Barray[ib], 1, dBarray, 1, queue);
-            device_setvector<double*>(ibatch, (double**)&Carray[ib], 1, dCarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Aarray[ib], 1, dAarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Barray[ib], 1, dBarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Carray[ib], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -248,7 +260,7 @@ void blas::batch::gemm(
 
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -265,15 +277,16 @@ void blas::batch::gemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check< std::complex<float> >( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
+        gemm_check< std::complex<float> >(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            batch, info );
     }
 
     bool fixed_size =   ( transA.size() == 1     &&
@@ -314,9 +327,15 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector< std::complex<float> *>(ibatch, (std::complex<float>**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector< std::complex<float> *>(ibatch, (std::complex<float>**)&Barray[ib], 1, dBarray, 1, queue);
-            device_setvector< std::complex<float> *>(ibatch, (std::complex<float>**)&Carray[ib], 1, dCarray, 1, queue);
+            device_setvector< std::complex<float> *>(
+                ibatch, (std::complex<float>**) &Aarray[ib], 1,
+                dAarray, 1, queue);
+            device_setvector< std::complex<float> *>(
+                ibatch, (std::complex<float>**) &Barray[ib], 1,
+                dBarray, 1, queue);
+            device_setvector< std::complex<float> *>(
+                ibatch, (std::complex<float>**) &Carray[ib], 1,
+                dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -366,7 +385,7 @@ void blas::batch::gemm(
 
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -383,15 +402,16 @@ void blas::batch::gemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check< std::complex<double> >( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
+        gemm_check< std::complex<double> >(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            batch, info );
     }
 
     bool fixed_size =   ( transA.size() == 1     &&
@@ -432,9 +452,12 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector< std::complex<double> *>(ibatch, (std::complex<double>**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector< std::complex<double> *>(ibatch, (std::complex<double>**)&Barray[ib], 1, dBarray, 1, queue);
-            device_setvector< std::complex<double> *>(ibatch, (std::complex<double>**)&Carray[ib], 1, dCarray, 1, queue);
+            device_setvector< std::complex<double> *>(
+                ibatch, (std::complex<double>**) &Aarray[ib], 1, dAarray, 1, queue);
+            device_setvector< std::complex<double> *>(
+                ibatch, (std::complex<double>**) &Barray[ib], 1, dBarray, 1, queue);
+            device_setvector< std::complex<double> *>(
+                ibatch, (std::complex<double>**) &Carray[ib], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -485,7 +508,7 @@ void blas::batch::gemm(
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
 //  an API for group of fixed size (in fact, fixed params)
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -505,8 +528,10 @@ void blas::batch::gemm(
     if (group_count == 0)
         return;
 
-    blas_error_if( layout      != Layout::ColMajor && layout      != Layout::RowMajor );
-    blas_error_if( info.size() != 0                && info.size() != group_count );
+    blas_error_if( layout != Layout::ColMajor
+                && layout != Layout::RowMajor );
+    blas_error_if( info.size() != 0
+                && info.size() != group_count );
 
     for (size_t ig = 0; ig < group_count; ig++) {
         batch_size += group_size[ ig ];
@@ -532,12 +557,13 @@ void blas::batch::gemm(
 
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<float>( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        group_count, info );
+        gemm_check<float>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+               Barray, lddb,
+            beta,  Carray, lddc,
+            group_count, info );
     }
 
     // set device
@@ -567,16 +593,19 @@ void blas::batch::gemm(
 
         // each group is submitted to a different stream using strides of batch_limit
         // first, get the device pointer array for the current stream
-        dAarray = (float**)queue.get_dev_ptr_array();
+        dAarray = (float**) queue.get_dev_ptr_array();
         dBarray = dAarray + batch_limit;
         dCarray = dBarray + batch_limit;
         for (size_t ib = 0; ib < batch; ib += batch_limit) {
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<float*>(ibatch, (float**)&Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<float*>(ibatch, (float**)&Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<float*>(ibatch, (float**)&Carray[ processed+ib ], 1, dCarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Aarray[ processed+ib ], 1, dAarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Barray[ processed+ib ], 1, dBarray, 1, queue);
+            device_setvector<float*>(
+                ibatch, (float**) &Carray[ processed+ib ], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -609,7 +638,7 @@ void blas::batch::gemm(
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
 //  an API for group of fixed size (in fact, fixed params)
-void blas::batch::gemm(
+void gemm(
     blas::Layout                 layout,
     std::vector<blas::Op> const &transA,
     std::vector<blas::Op> const &transB,
@@ -629,8 +658,10 @@ void blas::batch::gemm(
     if (group_count == 0)
         return;
 
-    blas_error_if( layout      != Layout::ColMajor && layout      != Layout::RowMajor );
-    blas_error_if( info.size() != 0                && info.size() != group_count );
+    blas_error_if( layout != Layout::ColMajor
+                && layout != Layout::RowMajor );
+    blas_error_if( info.size() != 0
+                && info.size() != group_count );
 
     for (size_t ig = 0; ig < group_count; ig++) {
         batch_size += group_size[ ig ];
@@ -656,12 +687,13 @@ void blas::batch::gemm(
 
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<double>( layout, transA, transB,
-                                         m, n, k,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         beta,  Carray, lddc,
-                                         group_count, info );
+        gemm_check<double>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            group_count, info );
     }
 
     // set device
@@ -691,16 +723,19 @@ void blas::batch::gemm(
 
         // each group is submitted to a different stream using strides of batch_limit
         // first, get the device pointer array for the current stream
-        dAarray = (double**)queue.get_dev_ptr_array();
+        dAarray = (double**) queue.get_dev_ptr_array();
         dBarray = dAarray + batch_limit;
         dCarray = dBarray + batch_limit;
         for (size_t ib = 0; ib < batch; ib += batch_limit) {
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<double*>(ibatch, (double**)&Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<double*>(ibatch, (double**)&Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<double*>(ibatch, (double**)&Carray[ processed+ib ], 1, dCarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Aarray[ processed+ib ], 1, dAarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Barray[ processed+ib ], 1, dBarray, 1, queue);
+            device_setvector<double*>(
+                ibatch, (double**) &Carray[ processed+ib ], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -733,7 +768,7 @@ void blas::batch::gemm(
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
 //  an API for group of fixed size (in fact, fixed params)
-void blas::batch::gemm(
+void gemm(
     blas::Layout                              layout,
     std::vector<blas::Op>              const &transA,
     std::vector<blas::Op>              const &transB,
@@ -741,10 +776,10 @@ void blas::batch::gemm(
     std::vector<int64_t>               const &n,
     std::vector<int64_t>               const &k,
     std::vector<std::complex<float> >  const &alpha,
-    std::vector<std::complex<float>*>  const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>  const &Barray,     std::vector<int64_t> const &lddb,
+    std::vector<std::complex<float>*>  const &Aarray, std::vector<int64_t> const &ldda,
+    std::vector<std::complex<float>*>  const &Barray, std::vector<int64_t> const &lddb,
     std::vector<std::complex<float> >  const &beta,
-    std::vector<std::complex<float>*>  const &Carray,     std::vector<int64_t> const &lddc,
+    std::vector<std::complex<float>*>  const &Carray, std::vector<int64_t> const &lddc,
     std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
     blas::Queue &queue )
 {
@@ -753,8 +788,10 @@ void blas::batch::gemm(
     if (group_count == 0)
         return;
 
-    blas_error_if( layout      != Layout::ColMajor && layout      != Layout::RowMajor );
-    blas_error_if( info.size() != 0                && info.size() != group_count );
+    blas_error_if( layout != Layout::ColMajor
+            && layout != Layout::RowMajor );
+    blas_error_if( info.size() != 0
+                && info.size() != group_count );
 
     for (size_t ig = 0; ig < group_count; ig++) {
         batch_size += group_size[ ig ];
@@ -780,12 +817,13 @@ void blas::batch::gemm(
 
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<std::complex<float>>( layout, transA, transB,
-                                         m, n, k,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         beta,  Carray, lddc,
-                                         group_count, info );
+        gemm_check<std::complex<float>>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            group_count, info );
     }
 
     // set device
@@ -822,9 +860,15 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<std::complex<float>*>(ibatch, (std::complex<float>**)&Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<std::complex<float>*>(ibatch, (std::complex<float>**)&Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<std::complex<float>*>(ibatch, (std::complex<float>**)&Carray[ processed+ib ], 1, dCarray, 1, queue);
+            device_setvector<std::complex<float>*>(
+                ibatch, (std::complex<float>**) &Aarray[ processed+ib ], 1,
+                dAarray, 1, queue);
+            device_setvector<std::complex<float>*>(
+                ibatch, (std::complex<float>**) &Barray[ processed+ib ], 1,
+                dBarray, 1, queue);
+            device_setvector<std::complex<float>*>(
+                ibatch, (std::complex<float>**) &Carray[ processed+ib ], 1,
+                dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -857,7 +901,7 @@ void blas::batch::gemm(
 // -----------------------------------------------------------------------------
 /// @ingroup gemm
 //  an API for group of fixed size (in fact, fixed params)
-void blas::batch::gemm(
+void gemm(
     blas::Layout                              layout,
     std::vector<blas::Op>              const &transA,
     std::vector<blas::Op>              const &transB,
@@ -865,10 +909,10 @@ void blas::batch::gemm(
     std::vector<int64_t>               const &n,
     std::vector<int64_t>               const &k,
     std::vector<std::complex<double> >  const &alpha,
-    std::vector<std::complex<double>*>  const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>  const &Barray,     std::vector<int64_t> const &lddb,
+    std::vector<std::complex<double>*>  const &Aarray, std::vector<int64_t> const &ldda,
+    std::vector<std::complex<double>*>  const &Barray, std::vector<int64_t> const &lddb,
     std::vector<std::complex<double> >  const &beta,
-    std::vector<std::complex<double>*>  const &Carray,     std::vector<int64_t> const &lddc,
+    std::vector<std::complex<double>*>  const &Carray, std::vector<int64_t> const &lddc,
     std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
     blas::Queue &queue )
 {
@@ -877,7 +921,8 @@ void blas::batch::gemm(
     if (group_count == 0)
         return;
 
-    blas_error_if( layout      != Layout::ColMajor && layout      != Layout::RowMajor );
+    blas_error_if( layout != Layout::ColMajor
+                && layout != Layout::RowMajor );
     blas_error_if( info.size() != 0                && info.size() != group_count );
 
     for (size_t ig = 0; ig < group_count; ig++) {
@@ -904,12 +949,13 @@ void blas::batch::gemm(
 
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<std::complex<double>>( layout, transA, transB,
-                                         m, n, k,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         beta,  Carray, lddc,
-                                         group_count, info );
+        gemm_check<std::complex<double>>(
+            layout, transA, transB,
+            m, n, k,
+            alpha, Aarray, ldda,
+                   Barray, lddb,
+            beta,  Carray, lddc,
+            group_count, info );
     }
 
     // set device
@@ -946,9 +992,15 @@ void blas::batch::gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<std::complex<double>*>(ibatch, (std::complex<double>**)&Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<std::complex<double>*>(ibatch, (std::complex<double>**)&Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<std::complex<double>*>(ibatch, (std::complex<double>**)&Carray[ processed+ib ], 1, dCarray, 1, queue);
+            device_setvector<std::complex<double>*>(
+                ibatch, (std::complex<double>**) &Aarray[ processed+ib ], 1,
+                dAarray, 1, queue);
+            device_setvector<std::complex<double>*>(
+                ibatch, (std::complex<double>**) &Barray[ processed+ib ], 1,
+                dBarray, 1, queue);
+            device_setvector<std::complex<double>*>(
+                ibatch, (std::complex<double>**) &Carray[ processed+ib ], 1,
+                dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -977,3 +1029,6 @@ void blas::batch::gemm(
     if (group_count > 1)
         queue.join();
 }
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_gemm.cc
+++ b/src/device_batch_gemm.cc
@@ -85,11 +85,11 @@ void gemm(
 
             // copy Aarray, Barray, and Carray to device
             device_setvector<float*>(
-                ibatch, (float**) &Aarray[ib], 1, dAarray, 1, queue);
+                ibatch, (float**) &Aarray[ib], 1, dAarray, 1, queue );
             device_setvector<float*>(
-                ibatch, (float**) &Barray[ib], 1, dBarray, 1, queue);
+                ibatch, (float**) &Barray[ib], 1, dBarray, 1, queue );
             device_setvector<float*>(
-                ibatch, (float**) &Carray[ib], 1, dCarray, 1, queue);
+                ibatch, (float**) &Carray[ib], 1, dCarray, 1, queue );
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -206,11 +206,11 @@ void gemm(
 
             // copy Aarray, Barray, and Carray to device
             device_setvector<double*>(
-                ibatch, (double**) &Aarray[ib], 1, dAarray, 1, queue);
+                ibatch, (double**) &Aarray[ib], 1, dAarray, 1, queue );
             device_setvector<double*>(
-                ibatch, (double**) &Barray[ib], 1, dBarray, 1, queue);
+                ibatch, (double**) &Barray[ib], 1, dBarray, 1, queue );
             device_setvector<double*>(
-                ibatch, (double**) &Carray[ib], 1, dCarray, 1, queue);
+                ibatch, (double**) &Carray[ib], 1, dCarray, 1, queue );
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A
@@ -329,13 +329,13 @@ void gemm(
             // copy Aarray, Barray, and Carray to device
             device_setvector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Aarray[ib], 1,
-                dAarray, 1, queue);
+                dAarray, 1, queue );
             device_setvector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Barray[ib], 1,
-                dBarray, 1, queue);
+                dBarray, 1, queue );
             device_setvector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Carray[ib], 1,
-                dCarray, 1, queue);
+                dCarray, 1, queue );
 
             if (layout == Layout::RowMajor) {
                 // swap transA <=> transB, m <=> n, B <=> A

--- a/src/device_batch_hemm.cc
+++ b/src/device_batch_hemm.cc
@@ -26,7 +26,7 @@ void blas::batch::hemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<float>(
@@ -84,7 +84,7 @@ void blas::batch::hemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<double>(
@@ -142,7 +142,7 @@ void blas::batch::hemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<std::complex<float>>(
@@ -200,7 +200,7 @@ void blas::batch::hemm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::hemm_check<std::complex<double>>(

--- a/src/device_batch_hemm.cc
+++ b/src/device_batch_hemm.cc
@@ -174,9 +174,9 @@ void blas::batch::hemm(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::hemm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -232,9 +232,9 @@ void blas::batch::hemm(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::hemm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_her2k.cc
+++ b/src/device_batch_her2k.cc
@@ -58,9 +58,9 @@ void blas::batch::her2k(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -116,9 +116,9 @@ void blas::batch::her2k(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -174,9 +174,9 @@ void blas::batch::her2k(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -232,9 +232,9 @@ void blas::batch::her2k(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::her2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_her2k.cc
+++ b/src/device_batch_her2k.cc
@@ -26,7 +26,7 @@ void blas::batch::her2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<float, float>(
@@ -84,7 +84,7 @@ void blas::batch::her2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<double, double>(
@@ -142,7 +142,7 @@ void blas::batch::her2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<std::complex<float>, float>(
@@ -200,7 +200,7 @@ void blas::batch::her2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::her2k_check<std::complex<double>, double>(

--- a/src/device_batch_herk.cc
+++ b/src/device_batch_herk.cc
@@ -54,8 +54,8 @@ void blas::batch::herk(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -107,8 +107,8 @@ void blas::batch::herk(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -160,8 +160,8 @@ void blas::batch::herk(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -213,8 +213,8 @@ void blas::batch::herk(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::herk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_herk.cc
+++ b/src/device_batch_herk.cc
@@ -25,7 +25,7 @@ void blas::batch::herk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<float, float>(
@@ -78,7 +78,7 @@ void blas::batch::herk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<double, double>(
@@ -131,7 +131,7 @@ void blas::batch::herk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<std::complex<float>, float>(
@@ -184,7 +184,7 @@ void blas::batch::herk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::herk_check<std::complex<double>, double>(

--- a/src/device_batch_symm.cc
+++ b/src/device_batch_symm.cc
@@ -58,9 +58,9 @@ void blas::batch::symm(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -116,9 +116,9 @@ void blas::batch::symm(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -174,9 +174,9 @@ void blas::batch::symm(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -232,9 +232,9 @@ void blas::batch::symm(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::symm(
             layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_symm.cc
+++ b/src/device_batch_symm.cc
@@ -26,7 +26,7 @@ void blas::batch::symm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<float>(
@@ -84,7 +84,7 @@ void blas::batch::symm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<double>(
@@ -142,7 +142,7 @@ void blas::batch::symm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<std::complex<float>>(
@@ -200,7 +200,7 @@ void blas::batch::symm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::symm_check<std::complex<double>>(

--- a/src/device_batch_syr2k.cc
+++ b/src/device_batch_syr2k.cc
@@ -58,9 +58,9 @@ void blas::batch::syr2k(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -116,9 +116,9 @@ void blas::batch::syr2k(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -174,9 +174,9 @@ void blas::batch::syr2k(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -232,9 +232,9 @@ void blas::batch::syr2k(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::syr2k(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-                    dB_, ldb_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+                    dB_, ldb_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_syr2k.cc
+++ b/src/device_batch_syr2k.cc
@@ -26,7 +26,7 @@ void blas::batch::syr2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<float>(
@@ -84,7 +84,7 @@ void blas::batch::syr2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<double>(
@@ -142,7 +142,7 @@ void blas::batch::syr2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<std::complex<float>>(
@@ -200,7 +200,7 @@ void blas::batch::syr2k(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syr2k_check<std::complex<double>>(

--- a/src/device_batch_syrk.cc
+++ b/src/device_batch_syrk.cc
@@ -25,7 +25,7 @@ void blas::batch::syrk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<float>(
@@ -78,7 +78,7 @@ void blas::batch::syrk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<double>(
@@ -131,7 +131,7 @@ void blas::batch::syrk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<std::complex<float>>(
@@ -184,7 +184,7 @@ void blas::batch::syrk(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::syrk_check<std::complex<double>>(

--- a/src/device_batch_syrk.cc
+++ b/src/device_batch_syrk.cc
@@ -54,8 +54,8 @@ void blas::batch::syrk(
         float* dC_   = blas::batch::extract<float*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -107,8 +107,8 @@ void blas::batch::syrk(
         double* dC_   = blas::batch::extract<double*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -160,8 +160,8 @@ void blas::batch::syrk(
         std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
@@ -213,8 +213,8 @@ void blas::batch::syrk(
         std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
         blas::syrk(
             layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_ ,
-            beta_,  dC_, ldc_ , queue );
+            alpha_, dA_, lda_,
+            beta_,  dC_, ldc_, queue );
         queue.revolve();
     }
     queue.join();

--- a/src/device_batch_trmm.cc
+++ b/src/device_batch_trmm.cc
@@ -26,7 +26,7 @@ void blas::batch::trmm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<float>( layout, side, uplo, trans, diag,
@@ -91,7 +91,7 @@ void blas::batch::trmm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<double>( layout, side, uplo, trans, diag,
@@ -156,7 +156,7 @@ void blas::batch::trmm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<std::complex<float>>( layout, side, uplo, trans, diag,
@@ -220,7 +220,7 @@ void blas::batch::trmm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trmm_check<std::complex<double>>( layout, side, uplo, trans, diag,

--- a/src/device_batch_trsm.cc
+++ b/src/device_batch_trsm.cc
@@ -29,7 +29,7 @@ void blas::batch::trsm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<float>( layout, side, uplo, trans, diag,
@@ -136,7 +136,7 @@ void blas::batch::trsm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<double>( layout, side, uplo, trans, diag,
@@ -243,7 +243,7 @@ void blas::batch::trsm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<std::complex<float>>( layout, side, uplo, trans, diag,
@@ -350,7 +350,7 @@ void blas::batch::trsm(
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch < 0 );
-    blas_error_if( !(info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
     if (info.size() > 0) {
         // perform error checking
         blas::batch::trsm_check<std::complex<double>>( layout, side, uplo, trans, diag,

--- a/src/device_hemm.cc
+++ b/src/device_hemm.cc
@@ -60,8 +60,6 @@ void blas::hemm(
     std::complex<float>       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -73,9 +71,11 @@ void blas::hemm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );
@@ -133,8 +133,6 @@ void blas::hemm(
     std::complex<double>       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -146,9 +144,11 @@ void blas::hemm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -221,7 +221,7 @@ Queue::Queue( blas::Device device, int64_t batch_size )
         std::vector<cl::sycl::device> devices;
         enumerate_devices( devices );
         device_ = device;
-        if(devices.size() <= (size_t)device) {
+        if (devices.size() <= (size_t)device) {
             throw blas::Error( " invalid device id ", __func__ );
         }
 
@@ -230,7 +230,7 @@ Queue::Queue( blas::Device device, int64_t batch_size )
 
         // Optionally: make sycl::queue be in-order (otherwise default is out-of-order)
         sycl::property_list q_prop{sycl::property::queue::in_order()};
-        default_stream_ = new sycl::queue( sycl_device_ , q_prop );
+        default_stream_ = new sycl::queue( sycl_device_, q_prop );
 
         // make new sycl:queue (by default out-of-order execution)
         // default_stream_ = new sycl::queue( sycl_device_ );

--- a/src/device_symm.cc
+++ b/src/device_symm.cc
@@ -26,8 +26,6 @@ void blas::symm(
     float       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -39,9 +37,11 @@ void blas::symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );
@@ -99,8 +99,6 @@ void blas::symm(
     double       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -112,9 +110,11 @@ void blas::symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );
@@ -172,8 +172,6 @@ void blas::symm(
     std::complex<float>       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -185,9 +183,11 @@ void blas::symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );
@@ -245,8 +245,6 @@ void blas::symm(
     std::complex<double>       *dC, int64_t lddc,
     blas::Queue &queue )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -258,9 +256,11 @@ void blas::symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( ldda < m, "ldda %lld < m %lld", (lld) ldda, (lld) m );
+        blas_error_if_msg( ldda < m, "ldda %lld < m %lld",
+                           llong( ldda ), llong( m ) );
     else
-        blas_error_if_msg( ldda < n, "ldda %lld < n %lld", (lld) ldda, (lld) n );
+        blas_error_if_msg( ldda < n, "ldda %lld < n %lld",
+                           llong( ldda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( lddb < m );

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -77,7 +77,7 @@ device_blas_int get_device_count()
         auto platforms = sycl::platform::get_platforms();
         for (auto &platform : platforms) {
             auto devices = platform.get_devices();
-            for (auto &device : devices ) {
+            for (auto &device : devices) {
                 dev_count += device.is_gpu();
             }
         }
@@ -104,7 +104,7 @@ void enumerate_devices(std::vector<cl::sycl::device> &devices)
     auto platforms = sycl::platform::get_platforms();
     for (auto &platform : platforms) {
         auto all_devices = platform.get_devices();
-        for (auto &idevice : all_devices ) {
+        for (auto &idevice : all_devices) {
             if (idevice.is_gpu()) {
                 devices.push_back( idevice );
             }

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -117,7 +117,10 @@ void enumerate_devices(std::vector<cl::sycl::device> &devices)
 #endif
 
 // -----------------------------------------------------------------------------
-/// free a device pointer
+/// @deprecated: use device_free( ptr, queue ).
+/// Free a device memory space on the current device,
+/// allocated with device_malloc.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void device_free( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -138,7 +141,8 @@ void device_free( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a device pointer for a given device
+/// Free a device memory space, allocated with device_malloc,
+/// on the queue's device.
 void device_free( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -152,14 +156,16 @@ void device_free( void* ptr, blas::Queue &queue )
             hipFree( ptr ) );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-       blas_dev_call(
-           sycl::free( ptr, queue.stream() ) );
+        blas_dev_call(
+            sycl::free( ptr, queue.stream() ) );
     #endif
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr )
+/// @deprecated: use host_free_pinned( ptr, queue ).
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
+void host_free_pinned( void* ptr )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(
@@ -178,8 +184,8 @@ void device_free_pinned( void* ptr )
 }
 
 // -----------------------------------------------------------------------------
-/// free a pinned memory space
-void device_free_pinned( void* ptr,  blas::Queue &queue )
+/// Free a pinned host memory space, allocated with host_malloc_pinned.
+void host_free_pinned( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
         blas_dev_call(

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -10,7 +10,9 @@
 namespace blas {
 
 // -----------------------------------------------------------------------------
-// set device
+/// @deprecated
+/// Set current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void set_device( blas::Device device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -30,7 +32,9 @@ void set_device( blas::Device device )
 }
 
 // -----------------------------------------------------------------------------
-// get current device
+/// @deprecated
+/// Get current GPU device.
+/// (CUDA, ROCm only; doesn't work with SYCL.)
 void get_device( blas::Device *device )
 {
     #ifdef BLAS_HAVE_CUBLAS
@@ -54,7 +58,7 @@ void get_device( blas::Device *device )
 }
 
 // -----------------------------------------------------------------------------
-// @return number of GPU devices
+/// @return number of GPU devices.
 device_blas_int get_device_count()
 {
     device_blas_int dev_count = 0;
@@ -70,13 +74,13 @@ device_blas_int get_device_count()
             blas_dev_call( err );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-    auto platforms = sycl::platform::get_platforms();
-    for (auto &platform : platforms) {
-        auto devices = platform.get_devices();
-        for (auto &device : devices ) {
-            dev_count += device.is_gpu();
+        auto platforms = sycl::platform::get_platforms();
+        for (auto &platform : platforms) {
+            auto devices = platform.get_devices();
+            for (auto &device : devices ) {
+                dev_count += device.is_gpu();
+            }
         }
-    }
 
     #else
         // return dev_count = 0
@@ -86,13 +90,13 @@ device_blas_int get_device_count()
 }
 
 // -----------------------------------------------------------------------------
-// @return a vector of sycl gpu devices
+/// @return vector of SYCL GPU devices.
 #ifdef BLAS_HAVE_ONEMKL
 void enumerate_devices(std::vector<cl::sycl::device> &devices)
 {
     device_blas_int dev_count = get_device_count();
 
-    if(devices.size() != (size_t)dev_count) {
+    if (devices.size() != (size_t)dev_count) {
         devices.clear();
         devices.reserve( dev_count );
     }

--- a/src/hemm.cc
+++ b/src/hemm.cc
@@ -58,8 +58,6 @@ void hemm(
     std::complex<float> beta,
     std::complex<float>       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -71,9 +69,11 @@ void hemm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );
@@ -129,8 +129,6 @@ void hemm(
     std::complex<double> beta,
     std::complex<double>       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -142,9 +140,11 @@ void hemm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );

--- a/src/onemkl_wrappers.cc
+++ b/src/onemkl_wrappers.cc
@@ -1167,7 +1167,7 @@ void batch_sgemm(
     // todo: probably move transA_/transB_ to blas::Queue
     std::vector<oneapi::mkl::transpose> transA_(group_count);
     std::vector<oneapi::mkl::transpose> transB_(group_count);
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         transA_[i] = op2onemkl( transA[i] );
         transB_[i] = op2onemkl( transB[i] );
     }
@@ -1238,7 +1238,7 @@ void batch_dgemm(
     // todo: probably move transA_/transB_ to blas::Queue
     std::vector<oneapi::mkl::transpose> transA_(group_count);
     std::vector<oneapi::mkl::transpose> transB_(group_count);
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         transA_[i] = op2onemkl( transA[i] );
         transB_[i] = op2onemkl( transB[i] );
     }
@@ -1309,7 +1309,7 @@ void batch_cgemm(
     // todo: probably move transA_/transB_ to blas::Queue
     std::vector<oneapi::mkl::transpose> transA_(group_count);
     std::vector<oneapi::mkl::transpose> transB_(group_count);
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         transA_[i] = op2onemkl( transA[i] );
         transB_[i] = op2onemkl( transB[i] );
     }
@@ -1380,7 +1380,7 @@ void batch_zgemm(
     // todo: probably move transA_/transB_ to blas::Queue
     std::vector<oneapi::mkl::transpose> transA_(group_count);
     std::vector<oneapi::mkl::transpose> transB_(group_count);
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         transA_[i] = op2onemkl( transA[i] );
         transB_[i] = op2onemkl( transB[i] );
     }
@@ -1427,7 +1427,7 @@ void batch_strsm(
     blas_dev_call(
         oneapi::mkl::blas::trsm_batch(
         dev_queue,
-        &side_, &uplo_ , &trans_, &diag_,
+        &side_, &uplo_, &trans_, &diag_,
         &m, &n,
         &alpha,
         (const float**)dAarray, &ldda,
@@ -1453,7 +1453,7 @@ void batch_strsm(
     std::vector<oneapi::mkl::transpose> trans_(group_count);
     std::vector<oneapi::mkl::diag>      diag_(group_count);
 
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         side_[i]  = side2onemkl( side[i] );
         uplo_[i]  = uplo2onemkl( uplo[i] );
         trans_[i] = op2onemkl( trans[i] );
@@ -1500,7 +1500,7 @@ void batch_dtrsm(
     blas_dev_call(
         oneapi::mkl::blas::trsm_batch(
         dev_queue,
-        &side_, &uplo_ , &trans_, &diag_,
+        &side_, &uplo_, &trans_, &diag_,
         &m, &n,
         &alpha,
         (const double**)dAarray, &ldda,
@@ -1526,7 +1526,7 @@ void batch_dtrsm(
     std::vector<oneapi::mkl::transpose> trans_(group_count);
     std::vector<oneapi::mkl::diag>      diag_(group_count);
 
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         side_[i]  = side2onemkl( side[i] );
         uplo_[i]  = uplo2onemkl( uplo[i] );
         trans_[i] = op2onemkl( trans[i] );
@@ -1573,7 +1573,7 @@ void batch_ctrsm(
     blas_dev_call(
         oneapi::mkl::blas::trsm_batch(
         dev_queue,
-        &side_, &uplo_ , &trans_, &diag_,
+        &side_, &uplo_, &trans_, &diag_,
         &m, &n,
         &alpha,
         (const std::complex<float>**)dAarray, &ldda,
@@ -1599,7 +1599,7 @@ void batch_ctrsm(
     std::vector<oneapi::mkl::transpose> trans_(group_count);
     std::vector<oneapi::mkl::diag>      diag_(group_count);
 
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         side_[i]  = side2onemkl( side[i] );
         uplo_[i]  = uplo2onemkl( uplo[i] );
         trans_[i] = op2onemkl( trans[i] );
@@ -1646,7 +1646,7 @@ void batch_ztrsm(
     blas_dev_call(
         oneapi::mkl::blas::trsm_batch(
         dev_queue,
-        &side_, &uplo_ , &trans_, &diag_,
+        &side_, &uplo_, &trans_, &diag_,
         &m, &n,
         &alpha,
         (const std::complex<double>**)dAarray, &ldda,
@@ -1672,7 +1672,7 @@ void batch_ztrsm(
     std::vector<oneapi::mkl::transpose> trans_(group_count);
     std::vector<oneapi::mkl::diag>      diag_(group_count);
 
-    for(auto i = 0; i < group_count; ++i) {
+    for (auto i = 0; i < group_count; ++i) {
         side_[i]  = side2onemkl( side[i] );
         uplo_[i]  = uplo2onemkl( uplo[i] );
         trans_[i] = op2onemkl( trans[i] );

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -26,8 +26,6 @@ void symm(
     float beta,
     float       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -39,9 +37,11 @@ void symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );
@@ -93,8 +93,6 @@ void symm(
     double beta,
     double       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -106,9 +104,11 @@ void symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );
@@ -160,8 +160,6 @@ void symm(
     std::complex<float> beta,
     std::complex<float>       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -173,9 +171,11 @@ void symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );
@@ -231,8 +231,6 @@ void symm(
     std::complex<double> beta,
     std::complex<double>       *C, int64_t ldc )
 {
-    typedef long long lld;
-
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -244,9 +242,11 @@ void symm(
     blas_error_if( n < 0 );
 
     if (side == Side::Left)
-        blas_error_if_msg( lda < m, "lda %lld < m %lld", (lld) lda, (lld) m );
+        blas_error_if_msg( lda < m, "lda %lld < m %lld",
+                           llong( lda ), llong( m ) );
     else
-        blas_error_if_msg( lda < n, "lda %lld < n %lld", (lld) lda, (lld) n );
+        blas_error_if_msg( lda < n, "lda %lld < n %lld",
+                           llong( lda ), llong( n ) );
 
     if (layout == Layout::ColMajor) {
         blas_error_if( ldb < m );

--- a/test/check_gemm.hh
+++ b/test/check_gemm.hh
@@ -17,7 +17,7 @@
 // Computes error for multiplication with general matrix result.
 // Covers dot, gemv, ger, geru, gemm, symv, hemv, symm, trmv, trsv?, trmm, trsm?.
 // Cnorm is norm of original C, before multiplication operation.
-template< typename T >
+template <typename T>
 void check_gemm(
     int64_t m, int64_t n, int64_t k,
     T alpha,
@@ -85,7 +85,7 @@ void check_gemm(
 // alpha    real    complex real    complex complex complex complex complex
 // beta     --      --      real    real    --      --      complex complex
 // zsyr2 doesn't exist in standard BLAS or LAPACK.
-template< typename TA, typename TB, typename T >
+template <typename TA, typename TB, typename T>
 void check_herk(
     blas::Uplo uplo,
     int64_t n, int64_t k,

--- a/test/check_gemm.hh
+++ b/test/check_gemm.hh
@@ -31,8 +31,6 @@ void check_gemm(
     blas::real_type<T> error[1],
     bool* okay )
 {
-    typedef long long int lld;
-
     #define    C(i_, j_)    C[ (i_) + (j_)*ldc ]
     #define Cref(i_, j_) Cref[ (i_) + (j_)*ldcref ]
 
@@ -57,9 +55,12 @@ void check_gemm(
              / (sqrt(real_t(k)+2)*std::abs(alpha)*Anorm*Bnorm
                  + 2*std::abs(beta)*Cnorm);
     if (verbose) {
-        printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2) * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
-                Cout_norm, (lld) k, std::abs(alpha), Anorm, Bnorm,
-                std::abs(beta), Cnorm, error[0] );
+        printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2)"
+                " * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e"
+                " + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
+                Cout_norm, llong( k ),
+                std::abs( alpha ), Anorm, Bnorm,
+                std::abs( beta ), Cnorm, error[0] );
     }
 
     // complex needs extra factor; see Higham, 2002, sec. 3.6.
@@ -99,8 +100,6 @@ void check_herk(
     blas::real_type<T> error[1],
     bool* okay )
 {
-    typedef long long int lld;
-
     #define    C(i_, j_)    C[ (i_) + (j_)*ldc ]
     #define Cref(i_, j_) Cref[ (i_) + (j_)*ldcref ]
 
@@ -137,9 +136,12 @@ void check_herk(
              / (sqrt(real_t(k)+2)*std::abs(alpha)*Anorm*Bnorm
                  + 2*std::abs(beta)*Cnorm);
     if (verbose) {
-        printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2) * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
-                Cout_norm, (lld) k, std::abs(alpha), Anorm, Bnorm,
-                std::abs(beta), Cnorm, error[0] );
+        printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2)"
+                " * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e"
+                " + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
+                Cout_norm, llong( k ),
+                std::abs( alpha ), Anorm, Bnorm,
+                std::abs( beta ), Cnorm, error[0] );
     }
 
     // complex needs extra factor; see Higham, 2002, sec. 3.6.

--- a/test/lapack_wrappers.hh
+++ b/test/lapack_wrappers.hh
@@ -14,7 +14,7 @@
 // until the real lapackpp wrappers are available.
 
 // -----------------------------------------------------------------------------
-template < typename TX > inline
+template <typename TX>
 void lapack_larnv( int64_t idist, int iseed[4], int64_t size, TX *x )
 {
     for (int64_t i = 0; i < size; ++i) {
@@ -22,7 +22,7 @@ void lapack_larnv( int64_t idist, int iseed[4], int64_t size, TX *x )
     }
 }
 
-template < typename TX > inline
+template <typename TX>
 void lapack_larnv( int64_t idist, int iseed[4], int64_t size, std::complex <TX> *x )
 {
     for (int64_t i = 0; i < size; ++i) {
@@ -115,7 +115,7 @@ double lapack_lantr( char const *norm, char const *uplo, char const *diag,
                      double *work );
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB > inline
+template <typename TA, typename TB> inline
 void lapack_lacpy( char const* uplo,
                      int64_t m, int64_t n,
                      TA const *A, int64_t lda,

--- a/test/lapack_wrappers.hh
+++ b/test/lapack_wrappers.hh
@@ -115,7 +115,7 @@ double lapack_lantr( char const *norm, char const *uplo, char const *diag,
                      double *work );
 
 // -----------------------------------------------------------------------------
-template <typename TA, typename TB> inline
+template <typename TA, typename TB>
 void lapack_lacpy( char const* uplo,
                      int64_t m, int64_t n,
                      TA const *A, int64_t lda,

--- a/test/print_matrix.hh
+++ b/test/print_matrix.hh
@@ -10,7 +10,7 @@
 #include <complex>
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void print_matrix( int64_t m, int64_t n, T *A, int64_t lda,
                    const char* format="%9.4f" )
 {
@@ -35,7 +35,7 @@ void print_matrix( int64_t m, int64_t n, T *A, int64_t lda,
 }
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void print_matrix( int64_t m, int64_t n, std::complex<T>* A, int64_t lda,
                    const char* format="%9.4f" )
 {
@@ -60,7 +60,7 @@ void print_matrix( int64_t m, int64_t n, std::complex<T>* A, int64_t lda,
 }
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void print_vector( int64_t n, T *x, int64_t incx,
                    const char* format="%9.4f" )
 {
@@ -79,7 +79,7 @@ void print_vector( int64_t n, T *x, int64_t incx,
 }
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void print_vector( int64_t n, std::complex<T>* x, int64_t incx,
                    const char* format="%9.4f" )
 {

--- a/test/test.hh
+++ b/test/test.hh
@@ -10,6 +10,12 @@
 #include "blas.hh"
 
 // -----------------------------------------------------------------------------
+// For printf, int64_t could be long (%ld), which is >= 32 bits,
+// or long long (%lld), guaranteed >= 64 bits.
+// Cast to llong to ensure printing 64 bits.
+using llong = long long;
+
+// -----------------------------------------------------------------------------
 class Params: public testsweeper::ParamsBase
 {
 public:

--- a/test/test.hh
+++ b/test/test.hh
@@ -88,7 +88,7 @@ public:
 };
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 inline T roundup( T x, T y )
 {
     return T( (x + y - 1) / y ) * y;

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -17,7 +17,6 @@ void test_asum_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<T> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -54,7 +53,7 @@ void test_asum_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "x = " ); print_vector( n, x, incx );

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_asum_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -15,8 +15,7 @@ template< typename T >
 void test_asum_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<T> real_t;
+    using real_t   = blas::real_type< T >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -65,8 +65,8 @@ void test_asum_work( Params& params, bool run )
     real_t result = blas::asum( n, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < T >::asum( n );
-    double gbyte = Gbyte < T >::asum( n );
+    double gflop = blas::Gflop< T >::asum( n );
+    double gbyte = blas::Gbyte< T >::asum( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_axpy_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -15,9 +15,10 @@ template< typename TX, typename TY >
 void test_axpy_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using scalar_t = blas::scalar_type< TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     scalar_t alpha  = params.alpha();
@@ -81,7 +82,7 @@ void test_axpy_work( Params& params, bool run )
     time = get_wtime() - time;
 
     double gflop = blas::Gflop< scalar_t >::axpy( n );
-    double gbyte = Gbyte< scalar_t >::axpy( n );
+    double gbyte = blas::Gbyte< scalar_t >::axpy( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -18,7 +18,6 @@ void test_axpy_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     scalar_t alpha  = params.alpha();
@@ -65,8 +64,8 @@ void test_axpy_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -80,7 +80,7 @@ void test_axpy_work( Params& params, bool run )
     blas::axpy( n, alpha, x, incx, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::axpy( n );
+    double gflop = blas::Gflop< scalar_t >::axpy( n );
     double gbyte = Gbyte< scalar_t >::axpy( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -14,9 +14,10 @@ template< typename Tx, typename Ty >
 void test_axpy_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<Tx, Ty> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using scalar_t = blas::scalar_type< Tx, Ty >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     scalar_t alpha  = params.alpha();

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename Tx, typename Ty >
+template <typename Tx, typename Ty>
 void test_axpy_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -94,8 +94,8 @@ void test_axpy_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop <Ty>::axpy( n );
-    double gbyte = Gbyte <Ty>::axpy( n );
+    double gflop = blas::Gflop< Ty >::axpy( n );
+    double gbyte = blas::Gbyte< Ty >::axpy( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -17,7 +17,6 @@ void test_axpy_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<Tx, Ty> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     scalar_t alpha  = params.alpha();
@@ -80,7 +79,7 @@ void test_axpy_device_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "n=%5lld, incx=%5lld, sizex=%10lld, incy=%5lld, sizey=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",
@@ -129,26 +128,26 @@ void test_axpy_device_work( Params& params, bool run )
         int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         for (int64_t i = 0; i < n; ++i) {
-            y[iy] = std::abs( y[iy] - yref[iy] )                                
-                  / (2*(std::abs( alpha * x[ix] ) + std::abs( y0[iy] )));       
-            ix += incx;                                                         
+            y[iy] = std::abs( y[iy] - yref[iy] )
+                  / (2*(std::abs( alpha * x[ix] ) + std::abs( y0[iy] )));
+            ix += incx;
             iy += incy;
         }
         params.error() = error;
 
 
-        if (verbose >= 2) {                                                     
-            printf( "err  = " ); print_vector( n, y, incy, "%9.2e" );           
-        }                                                                       
-                                                                                
-        // complex needs extra factor; see Higham, 2002, sec. 3.6.              
-        if (blas::is_complex<scalar_t>::value) {                                
-            error /= 2*sqrt(2);                                                 
-        }                                                                       
-                                                                                
-        real_t u = 0.5 * std::numeric_limits< real_t >::epsilon();              
-        params.error() = error;                                                 
-        params.okay() = (error < u);  
+        if (verbose >= 2) {
+            printf( "err  = " ); print_vector( n, y, incy, "%9.2e" );
+        }
+
+        // complex needs extra factor; see Higham, 2002, sec. 3.6.
+        if (blas::is_complex<scalar_t>::value) {
+            error /= 2*sqrt(2);
+        }
+
+        real_t u = 0.5 * std::numeric_limits< real_t >::epsilon();
+        params.error() = error;
+        params.okay() = (error < u);
 
     }
 

--- a/test/test_batch_gemm.cc
+++ b/test/test_batch_gemm.cc
@@ -124,7 +124,7 @@ void test_batch_gemm_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::gemm( m_, n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::gemm( m_, n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_gemm.cc
+++ b/test/test_batch_gemm.cc
@@ -16,10 +16,11 @@ template< typename TA, typename TB, typename TC >
 void test_batch_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using namespace blas::batch;
+    using blas::Op;
+    using blas::Layout;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -149,7 +150,7 @@ void test_batch_gemm_work( Params& params, bool run )
         for (size_t i = 0; i < batch; ++i) {
             check_gemm( Cm, Cn, k_, alpha_, beta_, Anorm[i], Bnorm[i], Cnorm[i],
                         Crefarray[i], ldc_, Carray[i], ldc_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_gemm.cc
+++ b/test/test_batch_gemm.cc
@@ -20,7 +20,6 @@ void test_batch_gemm_work( Params& params, bool run )
     using namespace blas::batch;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_gemm.cc
+++ b/test/test_batch_gemm.cc
@@ -12,7 +12,7 @@
 
 #include "blas.hh"
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_gemm_device.cc
+++ b/test/test_batch_gemm_device.cc
@@ -147,7 +147,7 @@ void test_device_batch_gemm_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::gemm( m_, n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::gemm( m_, n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);

--- a/test/test_batch_gemm_device.cc
+++ b/test/test_batch_gemm_device.cc
@@ -15,10 +15,11 @@ template< typename TA, typename TB, typename TC >
 void test_device_batch_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using namespace blas::batch;
+    using blas::Op;
+    using blas::Layout;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -174,7 +175,7 @@ void test_device_batch_gemm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Cm, Cn, k_, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_gemm_device.cc
+++ b/test/test_batch_gemm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_device_batch_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_gemm_device.cc
+++ b/test/test_batch_gemm_device.cc
@@ -19,7 +19,6 @@ void test_device_batch_gemm_work( Params& params, bool run )
     using namespace blas::batch;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_hemm.cc
+++ b/test/test_batch_hemm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_hemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_hemm.cc
+++ b/test/test_batch_hemm.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_hemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Layout;
+    using blas::Side;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -136,7 +137,7 @@ void test_batch_hemm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Cm, Cn, An, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_hemm.cc
+++ b/test/test_batch_hemm.cc
@@ -111,7 +111,7 @@ void test_batch_hemm_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::hemm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::hemm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_hemm.cc
+++ b/test/test_batch_hemm.cc
@@ -18,7 +18,6 @@ void test_batch_hemm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_hemm_device.cc
+++ b/test/test_batch_hemm_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_hemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -163,7 +164,7 @@ void test_batch_hemm_device_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Cm, Cn, An, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_hemm_device.cc
+++ b/test/test_batch_hemm_device.cc
@@ -18,7 +18,6 @@ void test_batch_hemm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_hemm_device.cc
+++ b/test/test_batch_hemm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_hemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_hemm_device.cc
+++ b/test/test_batch_hemm_device.cc
@@ -136,7 +136,7 @@ void test_batch_hemm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::hemm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::hemm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_her2k.cc
+++ b/test/test_batch_her2k.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_her2k_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -135,7 +136,7 @@ void test_batch_her2k_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_herk( uplo_, n_, 2*k_, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_her2k.cc
+++ b/test/test_batch_her2k.cc
@@ -110,7 +110,7 @@ void test_batch_her2k_work( Params& params, bool run )
                         batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::her2k( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::her2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_her2k.cc
+++ b/test/test_batch_her2k.cc
@@ -18,7 +18,6 @@ void test_batch_her2k_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_her2k.cc
+++ b/test/test_batch_her2k.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_her2k_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_her2k_device.cc
+++ b/test/test_batch_her2k_device.cc
@@ -18,7 +18,6 @@ void test_batch_her2k_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_her2k_device.cc
+++ b/test/test_batch_her2k_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_her2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -162,7 +163,7 @@ void test_batch_her2k_device_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_herk( uplo_, n_, 2*k_, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_her2k_device.cc
+++ b/test/test_batch_her2k_device.cc
@@ -135,7 +135,7 @@ void test_batch_her2k_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::her2k( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::her2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);

--- a/test/test_batch_her2k_device.cc
+++ b/test/test_batch_her2k_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_her2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_herk.cc
+++ b/test/test_batch_herk.cc
@@ -101,7 +101,7 @@ void test_batch_herk_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::herk( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::herk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_herk.cc
+++ b/test/test_batch_herk.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_batch_herk_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_herk.cc
+++ b/test/test_batch_herk.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TC >
 void test_batch_herk_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -127,7 +128,7 @@ void test_batch_herk_work( Params& params, bool run )
             check_herk( uplo_, n_, k_, alpha_, beta_, Anorm[s], Anorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_herk.cc
+++ b/test/test_batch_herk.cc
@@ -18,7 +18,6 @@ void test_batch_herk_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_herk_device.cc
+++ b/test/test_batch_herk_device.cc
@@ -18,7 +18,6 @@ void test_batch_herk_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_herk_device.cc
+++ b/test/test_batch_herk_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TC >
 void test_batch_herk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -150,7 +151,7 @@ void test_batch_herk_device_work( Params& params, bool run )
             check_herk( uplo_, n_, k_, alpha_, beta_, Anorm[s], Anorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_herk_device.cc
+++ b/test/test_batch_herk_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_batch_herk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_herk_device.cc
+++ b/test/test_batch_herk_device.cc
@@ -122,7 +122,7 @@ void test_batch_herk_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::herk( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::herk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);

--- a/test/test_batch_symm.cc
+++ b/test/test_batch_symm.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_symm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -136,7 +137,7 @@ void test_batch_symm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Cm, Cn, An, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_symm.cc
+++ b/test/test_batch_symm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_symm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_symm.cc
+++ b/test/test_batch_symm.cc
@@ -18,7 +18,6 @@ void test_batch_symm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_symm.cc
+++ b/test/test_batch_symm.cc
@@ -111,7 +111,7 @@ void test_batch_symm_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::symm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::symm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_symm_device.cc
+++ b/test/test_batch_symm_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_symm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -161,7 +162,7 @@ void test_batch_symm_device_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Cm, Cn, An, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_symm_device.cc
+++ b/test/test_batch_symm_device.cc
@@ -134,7 +134,7 @@ void test_batch_symm_device_work( Params& params, bool run )
                        batch, info, queue);
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::symm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::symm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_symm_device.cc
+++ b/test/test_batch_symm_device.cc
@@ -18,7 +18,6 @@ void test_batch_symm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_symm_device.cc
+++ b/test/test_batch_symm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_symm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_syr2k.cc
+++ b/test/test_batch_syr2k.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_syr2k_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -136,7 +137,7 @@ void test_batch_syr2k_work( Params& params, bool run )
             check_herk( uplo_, n_, 2*k_, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_syr2k.cc
+++ b/test/test_batch_syr2k.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_syr2k_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_syr2k.cc
+++ b/test/test_batch_syr2k.cc
@@ -18,7 +18,6 @@ void test_batch_syr2k_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_syr2k.cc
+++ b/test/test_batch_syr2k.cc
@@ -110,7 +110,7 @@ void test_batch_syr2k_work( Params& params, bool run )
                         batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::syr2k( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::syr2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_syr2k_device.cc
+++ b/test/test_batch_syr2k_device.cc
@@ -18,7 +18,6 @@ void test_batch_syr2k_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_syr2k_device.cc
+++ b/test/test_batch_syr2k_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB, typename TC >
 void test_batch_syr2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -163,7 +164,7 @@ void test_batch_syr2k_device_work( Params& params, bool run )
             check_herk( uplo_, n_, 2*k_, alpha_, beta_, Anorm[s], Bnorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_syr2k_device.cc
+++ b/test/test_batch_syr2k_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_batch_syr2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_syr2k_device.cc
+++ b/test/test_batch_syr2k_device.cc
@@ -135,7 +135,7 @@ void test_batch_syr2k_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::syr2k( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::syr2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);

--- a/test/test_batch_syrk.cc
+++ b/test/test_batch_syrk.cc
@@ -18,7 +18,6 @@ void test_batch_syrk_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_syrk.cc
+++ b/test/test_batch_syrk.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_batch_syrk_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_syrk.cc
+++ b/test/test_batch_syrk.cc
@@ -101,7 +101,7 @@ void test_batch_syrk_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::syrk( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::syrk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_syrk.cc
+++ b/test/test_batch_syrk.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TC >
 void test_batch_syrk_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -127,7 +128,7 @@ void test_batch_syrk_work( Params& params, bool run )
             check_herk( uplo_, n_, k_, alpha_, beta_, Anorm[s], Anorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_syrk_device.cc
+++ b/test/test_batch_syrk_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TC >
 void test_batch_syrk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -150,7 +151,7 @@ void test_batch_syrk_device_work( Params& params, bool run )
             check_herk( uplo_, n_, k_, alpha_, beta_, Anorm[s], Anorm[s], Cnorm[s],
                         Crefarray[s], ldc_, Carray[s], ldc_, verbose, &err, &ok );
 
-            error = max( error, err );
+            error = std::max( error, err );
             okay &= ok;
         }
 

--- a/test/test_batch_syrk_device.cc
+++ b/test/test_batch_syrk_device.cc
@@ -18,7 +18,6 @@ void test_batch_syrk_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_syrk_device.cc
+++ b/test/test_batch_syrk_device.cc
@@ -122,7 +122,7 @@ void test_batch_syrk_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::syrk( n_, k_ );
+    double gflop = batch * blas::Gflop< scalar_t >::syrk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);

--- a/test/test_batch_syrk_device.cc
+++ b/test/test_batch_syrk_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_batch_syrk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_trmm.cc
+++ b/test/test_batch_trmm.cc
@@ -18,7 +18,6 @@ void test_batch_trmm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_trmm.cc
+++ b/test/test_batch_trmm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_batch_trmm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_trmm.cc
+++ b/test/test_batch_trmm.cc
@@ -105,7 +105,7 @@ void test_batch_trmm_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::trmm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::trmm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_trmm.cc
+++ b/test/test_batch_trmm.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB >
 void test_batch_trmm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -134,7 +135,7 @@ void test_batch_trmm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Bm, Bn, Am, alpha_, scalar_t(0), Anorm[s], Bnorm[s], real_t(0),
                         Brefarray[s], ldb_, Barray[s], ldb_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_trmm_device.cc
+++ b/test/test_batch_trmm_device.cc
@@ -126,7 +126,7 @@ void test_batch_trmm_work_device( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::trmm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::trmm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_trmm_device.cc
+++ b/test/test_batch_trmm_device.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TB >
 void test_batch_trmm_work_device( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -158,7 +159,7 @@ void test_batch_trmm_work_device( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Bm, Bn, Am, alpha_, scalar_t(0), Anorm[s], Bnorm[s], real_t(0),
                         Brefarray[s], ldb_, Barray[s], ldb_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_trmm_device.cc
+++ b/test/test_batch_trmm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_batch_trmm_work_device( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_trmm_device.cc
+++ b/test/test_batch_trmm_device.cc
@@ -18,7 +18,6 @@ void test_batch_trmm_work_device( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_trsm.cc
+++ b/test/test_batch_trsm.cc
@@ -18,7 +18,6 @@ void test_batch_trsm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_batch_trsm.cc
+++ b/test/test_batch_trsm.cc
@@ -15,9 +15,11 @@ template< typename TA, typename TB >
 void test_batch_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -171,7 +173,7 @@ void test_batch_trsm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             check_gemm( Bm, Bn, Am, alpha_, scalar_t(0), Anorm[s], Bnorm[s], real_t(0),
                         Brefarray[s], ldb_, Barray[s], ldb_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_trsm.cc
+++ b/test/test_batch_trsm.cc
@@ -142,7 +142,7 @@ void test_batch_trsm_work( Params& params, bool run )
                        batch, info );
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::trsm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::trsm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_trsm.cc
+++ b/test/test_batch_trsm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_batch_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -15,10 +15,14 @@ template< typename TA, typename TB >
 void test_device_batch_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using namespace blas::batch;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -197,7 +201,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
         for (size_t i = 0; i < batch; ++i) {
             check_gemm( Bm, Bn, Am, alpha_, scalar_t(0), Anorm[i], Bnorm[i], real_t(0),
                         Brefarray[i], ldb_, Barray[i], ldb_, verbose, &err, &ok );
-            error = max(error, err);
+            error = std::max( error, err );
             okay &= ok;
         }
         params.error() = error;

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_device_batch_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -165,7 +165,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = batch * Gflop < scalar_t >::trsm( side_, m_, n_ );
+    double gflop = batch * blas::Gflop< scalar_t >::trsm( side_, m_, n_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -19,7 +19,6 @@ void test_device_batch_trsm_work( Params& params, bool run )
     using namespace blas::batch;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -15,9 +15,8 @@ template< typename TX, typename TY >
 void test_copy_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using scalar_t = blas::scalar_type< TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -18,7 +18,6 @@ void test_copy_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -62,8 +61,8 @@ void test_copy_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_copy_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -75,8 +75,8 @@ void test_copy_work( Params& params, bool run )
     blas::copy( n, x, incx, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::copy( n );
-    double gbyte = Gbyte < scalar_t >::copy( n );
+    double gflop = blas::Gflop< scalar_t >::copy( n );
+    double gbyte = blas::Gbyte< scalar_t >::copy( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -14,9 +14,8 @@ template< typename TX, typename TY >
 void test_copy_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using scalar_t = blas::scalar_type< TX, TY >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_copy_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -17,7 +17,6 @@ void test_copy_device_work( Params& params, bool run )
     using namespace blas;
     using scalar_t = blas::scalar_type< TX, TY >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -83,8 +82,8 @@ void test_copy_device_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -97,8 +97,8 @@ void test_copy_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::copy( n );
-    double gbyte = Gbyte < scalar_t >::copy( n );
+    double gflop = blas::Gflop< scalar_t >::copy( n );
+    double gbyte = blas::Gbyte< scalar_t >::copy( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_dot.cc
+++ b/test/test_dot.cc
@@ -77,8 +77,8 @@ void test_dot_work( Params& params, bool run )
     scalar_t result = blas::dot( n, x, incx, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::dot( n );
-    double gbyte = Gbyte < scalar_t >::dot( n );
+    double gflop = blas::Gflop< scalar_t >::dot( n );
+    double gbyte = blas::Gbyte< scalar_t >::dot( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_dot.cc
+++ b/test/test_dot.cc
@@ -15,9 +15,10 @@ template< typename TX, typename TY >
 void test_dot_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using scalar_t = blas::scalar_type< TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_dot.cc
+++ b/test/test_dot.cc
@@ -18,7 +18,6 @@ void test_dot_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -64,8 +63,8 @@ void test_dot_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm %.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm %.2e\n",
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "x = " ); print_vector( n, x, incx );

--- a/test/test_dot.cc
+++ b/test/test_dot.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_dot_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_dotu.cc
+++ b/test/test_dotu.cc
@@ -15,9 +15,10 @@ template< typename TX, typename TY >
 void test_dotu_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using scalar_t = blas::scalar_type< TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_dotu.cc
+++ b/test/test_dotu.cc
@@ -77,8 +77,8 @@ void test_dotu_work( Params& params, bool run )
     scalar_t result = blas::dotu( n, x, incx, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::dot( n );
-    double gbyte = Gbyte < scalar_t >::dot( n );
+    double gflop = blas::Gflop< scalar_t >::dot( n );
+    double gbyte = blas::Gbyte< scalar_t >::dot( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_dotu.cc
+++ b/test/test_dotu.cc
@@ -18,7 +18,6 @@ void test_dotu_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -64,8 +63,8 @@ void test_dotu_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm %.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm %.2e\n",
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "x = " ); print_vector( n, x, incx );

--- a/test/test_dotu.cc
+++ b/test/test_dotu.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_dotu_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_error.cc
+++ b/test/test_error.cc
@@ -8,8 +8,6 @@
 
 void test_error( Params& params, bool run )
 {
-    typedef long long lld;
-
     int64_t m = params.dim.m();
     int64_t n = params.dim.n();
 
@@ -25,7 +23,7 @@ void test_error( Params& params, bool run )
         blas_error_if( m == n );
     }
     else if (m == 200) {
-        blas_error_if_msg( m == n, "m %lld == n %lld", (lld) m, (lld) n );
+        blas_error_if_msg( m == n, "m %lld == n %lld", llong( m ), llong( n ) );
     }
     else if (m == 300) {
         assert( m != n );

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -18,7 +18,6 @@ void test_gemm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -108,9 +107,9 @@ void test_gemm_work( Params& params, bool run )
                 "A Am=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C Cm=%5lld, Cn=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm,
-                (lld) Cm, (lld) Cn, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( Cm ), llong( Cn ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -127,7 +127,7 @@ void test_gemm_work( Params& params, bool run )
                 alpha, A, lda, B, ldb, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::gemm( m, n, k );
+    double gflop = blas::Gflop< scalar_t >::gemm( m, n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TB, typename TC >
 void test_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_gemm.cc
+++ b/test/test_gemm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -18,7 +18,6 @@ void test_gemm_device_work( Params& params, bool run )
     using namespace blas;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -129,9 +128,9 @@ void test_gemm_device_work( Params& params, bool run )
                 "A Am=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C Cm=%5lld, Cn=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm,
-                (lld) Cm, (lld) Cn, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( Cm ), llong( Cn ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TB, typename TC >
 void test_gemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
+    using std::real;
+    using std::imag;
+    using blas::Op;
+    using blas::Layout;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -149,7 +149,7 @@ void test_gemm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::gemm( m, n, k );
+    double gflop = blas::Gflop< scalar_t >::gemm( m, n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_gemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_gemv_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -93,8 +93,8 @@ void test_gemv_work( Params& params, bool run )
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
                 llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
-                llong( Xm ), llong( incx ),          llong( size_x ), Xnorm,
-                llong( Ym ), llong( incy ),          llong( size_y ), Ynorm );
+                llong( Xm ), llong( incx ), llong( size_x ), Xnorm,
+                llong( Ym ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -18,7 +18,6 @@ void test_gemv_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -90,9 +89,9 @@ void test_gemv_work( Params& params, bool run )
                 "A Am=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Xm, (lld) incx,          (lld) size_x, Xnorm,
-                (lld) Ym, (lld) incy,          (lld) size_y, Ynorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Xm ), llong( incx ),          llong( size_x ), Xnorm,
+                llong( Ym ), llong( incy ),          llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -108,8 +108,8 @@ void test_gemv_work( Params& params, bool run )
     blas::gemv( layout, trans, m, n, alpha, A, lda, x, incx, beta, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop< scalar_t >::gemv( m, n );
-    double gbyte = Gbyte< scalar_t >::gemv( m, n );
+    double gflop = blas::Gflop< scalar_t >::gemv( m, n );
+    double gbyte = blas::Gbyte< scalar_t >::gemv( m, n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX, typename TY >
 void test_gemv_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_ger_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -18,7 +18,6 @@ void test_ger_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -85,9 +84,9 @@ void test_ger_work( Params& params, bool run )
                 "A Am=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld) incx,          (lld) size_x, Xnorm,
-                (lld)  n, (lld) incy,          (lld) size_y, Ynorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( incx ),          llong( size_x ), Xnorm,
+                llong( n ), llong( incy ),          llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -102,8 +102,8 @@ void test_ger_work( Params& params, bool run )
     blas::ger( layout, m, n, alpha, x, incx, y, incy, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop< scalar_t >::ger( m, n );
-    double gbyte = Gbyte< scalar_t >::ger( m, n );
+    double gflop = blas::Gflop< scalar_t >::ger( m, n );
+    double gbyte = blas::Gbyte< scalar_t >::ger( m, n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -87,8 +87,8 @@ void test_ger_work( Params& params, bool run )
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
                 llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
-                llong( m ), llong( incx ),          llong( size_x ), Xnorm,
-                llong( n ), llong( incy ),          llong( size_y ), Ynorm );
+                llong( m ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -15,9 +15,11 @@ template< typename TA, typename TX, typename TY >
 void test_ger_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_geru_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -102,8 +102,8 @@ void test_geru_work( Params& params, bool run )
     blas::geru( layout, m, n, alpha, x, incx, y, incy, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::ger( m, n );
-    double gbyte = Gbyte < scalar_t >::ger( m, n );
+    double gflop = blas::Gflop< scalar_t >::ger( m, n );
+    double gbyte = blas::Gbyte< scalar_t >::ger( m, n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -18,7 +18,6 @@ void test_geru_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -85,9 +84,9 @@ void test_geru_work( Params& params, bool run )
                 "A Am=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld) incx,          (lld) size_x, Xnorm,
-                (lld)  n, (lld) incy,          (lld) size_y, Ynorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( incx ),          llong( size_x ), Xnorm,
+                llong( n ), llong( incy ),          llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -15,9 +15,11 @@ template< typename TA, typename TX, typename TY >
 void test_geru_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -87,8 +87,8 @@ void test_geru_work( Params& params, bool run )
                 "x Xm=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n"
                 "y Ym=%5lld, inc=%5lld,           size=%10lld, norm=%.2e\n",
                 llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
-                llong( m ), llong( incx ),          llong( size_x ), Xnorm,
-                llong( n ), llong( incy ),          llong( size_y ), Ynorm );
+                llong( m ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -18,7 +18,6 @@ void test_hemm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -92,9 +91,9 @@ void test_hemm_work( Params& params, bool run )
                 "B  m=%5lld,  n=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  m=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 side2char(side), uplo2char(uplo),
-                (lld) An, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld)  n, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  m, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( An ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( n ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( m ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_hemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_hemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_hemm.cc
+++ b/test/test_hemm.cc
@@ -111,7 +111,7 @@ void test_hemm_work( Params& params, bool run )
                 alpha, A, lda, B, ldb, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::hemm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::hemm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_hemm_device.cc
+++ b/test/test_hemm_device.cc
@@ -133,7 +133,7 @@ void test_hemm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::hemm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::hemm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);

--- a/test/test_hemm_device.cc
+++ b/test/test_hemm_device.cc
@@ -18,7 +18,6 @@ void test_hemm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -113,9 +112,9 @@ void test_hemm_device_work( Params& params, bool run )
                 "B  m=%5lld,  n=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  m=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 side2char(side), uplo2char(uplo),
-                (lld) An, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld)  n, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  m, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( An ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( n ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( m ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_hemm_device.cc
+++ b/test/test_hemm_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_hemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_hemm_device.cc
+++ b/test/test_hemm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_hemm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_hemv.cc
+++ b/test/test_hemv.cc
@@ -18,7 +18,6 @@ void test_hemv_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -81,9 +80,9 @@ void test_hemv_work( Params& params, bool run )
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_hemv.cc
+++ b/test/test_hemv.cc
@@ -99,8 +99,8 @@ void test_hemv_work( Params& params, bool run )
     blas::hemv( layout, uplo, n, alpha, A, lda, x, incx, beta, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::hemv( n );
-    double gbyte = Gbyte < scalar_t >::hemv( n );
+    double gflop = blas::Gflop< scalar_t >::hemv( n );
+    double gbyte = blas::Gbyte< scalar_t >::hemv( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_hemv.cc
+++ b/test/test_hemv.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX, typename TY >
 void test_hemv_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_hemv.cc
+++ b/test/test_hemv.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_hemv_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_her.cc
+++ b/test/test_her.cc
@@ -87,8 +87,8 @@ void test_her_work( Params& params, bool run )
     blas::her( layout, uplo, n, alpha, x, incx, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::her( n );
-    double gbyte = Gbyte < scalar_t >::her( n );
+    double gflop = blas::Gflop< scalar_t >::her( n );
+    double gbyte = blas::Gbyte< scalar_t >::her( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_her.cc
+++ b/test/test_her.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void test_her_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_her.cc
+++ b/test/test_her.cc
@@ -18,7 +18,6 @@ void test_her_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -73,8 +72,8 @@ void test_her_work( Params& params, bool run )
         printf( "\n"
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e;\n", alpha );

--- a/test/test_her.cc
+++ b/test/test_her.cc
@@ -15,9 +15,10 @@ template< typename TA, typename TX >
 void test_her_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_her2.cc
+++ b/test/test_her2.cc
@@ -18,7 +18,6 @@ void test_her2_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -80,9 +79,9 @@ void test_her2_work( Params& params, bool run )
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_her2.cc
+++ b/test/test_her2.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_her2_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_her2.cc
+++ b/test/test_her2.cc
@@ -97,8 +97,8 @@ void test_her2_work( Params& params, bool run )
     blas::her2( layout, uplo, n, alpha, x, incx, y, incy, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::her2( n );
-    double gbyte = Gbyte < scalar_t >::her2( n );
+    double gflop = blas::Gflop< scalar_t >::her2( n );
+    double gbyte = blas::Gbyte< scalar_t >::her2( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_her2.cc
+++ b/test/test_her2.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX, typename TY >
 void test_her2_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_her2k_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -119,7 +119,7 @@ void test_her2k_work( Params& params, bool run )
                  alpha, A, lda, B, ldb, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::her2k( n, k );
+    double gflop = blas::Gflop< scalar_t >::her2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -18,7 +18,6 @@ void test_her2k_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -100,9 +99,9 @@ void test_her2k_work( Params& params, bool run )
                 "B Bn=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Am, (lld) An, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Am ), llong( An ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e;  %% beta real\n",

--- a/test/test_her2k.cc
+++ b/test/test_her2k.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_her2k_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_her2k_device.cc
+++ b/test/test_her2k_device.cc
@@ -18,7 +18,6 @@ void test_her2k_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -121,9 +120,9 @@ void test_her2k_device_work( Params& params, bool run )
                 "B Bn=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Am, (lld) An, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Am ), llong( An ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e;  %% beta real\n",

--- a/test/test_her2k_device.cc
+++ b/test/test_her2k_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_her2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_her2k_device.cc
+++ b/test/test_her2k_device.cc
@@ -141,7 +141,7 @@ void test_her2k_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::her2k( n, k );
+    double gflop = blas::Gflop< scalar_t >::her2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);

--- a/test/test_her2k_device.cc
+++ b/test/test_her2k_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_her2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -18,7 +18,6 @@ void test_herk_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -86,8 +85,8 @@ void test_herk_work( Params& params, bool run )
                 "A An=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e; beta = %.4e;  %% real\n", alpha, beta );

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -101,7 +101,7 @@ void test_herk_work( Params& params, bool run )
                 alpha, A, lda, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::herk( n, k );
+    double gflop = blas::Gflop< scalar_t >::herk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_herk_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_herk.cc
+++ b/test/test_herk.cc
@@ -15,9 +15,11 @@ template< typename TA, typename TC >
 void test_herk_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_herk_device.cc
+++ b/test/test_herk_device.cc
@@ -18,7 +18,6 @@ void test_herk_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -104,8 +103,8 @@ void test_herk_device_work( Params& params, bool run )
                 "A An=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e; beta = %.4e;  %% real\n", alpha, beta );

--- a/test/test_herk_device.cc
+++ b/test/test_herk_device.cc
@@ -15,9 +15,11 @@ template< typename TA, typename TC >
 void test_herk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_herk_device.cc
+++ b/test/test_herk_device.cc
@@ -120,7 +120,7 @@ void test_herk_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::herk( n, k );
+    double gflop = blas::Gflop< scalar_t >::herk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);

--- a/test/test_herk_device.cc
+++ b/test/test_herk_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_herk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -16,7 +16,6 @@ void test_iamax_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<T> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -53,7 +52,7 @@ void test_iamax_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "x = " ); print_vector( n, x, incx );
@@ -72,7 +71,7 @@ void test_iamax_work( Params& params, bool run )
     params.gbytes() = gbyte / time;
 
     if (verbose >= 1) {
-        printf( "result = %5lld\n", (lld) result );
+        printf( "result = %5lld\n", llong( result ) );
     }
 
     if (params.check() == 'y') {
@@ -87,7 +86,7 @@ void test_iamax_work( Params& params, bool run )
         params.ref_gbytes() = gbyte / time;
 
         if (verbose >= 1) {
-            printf( "ref    = %5lld\n", (lld) ref );
+            printf( "ref    = %5lld\n", llong( ref ) );
         }
 
         // error = |ref - result|

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -64,8 +64,8 @@ void test_iamax_work( Params& params, bool run )
     int64_t result = blas::iamax( n, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < T >::iamax( n );
-    double gbyte = Gbyte < T >::iamax( n );
+    double gflop = blas::Gflop< T >::iamax( n );
+    double gbyte = blas::Gbyte< T >::iamax( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -14,8 +14,7 @@ template< typename T >
 void test_iamax_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<T> real_t;
+    using real_t   = blas::real_type< T >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_iamax_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -88,10 +88,10 @@ void test_memcpy_work( Params& params, bool run )
     int64_t inc = std::max( inc_ac, inc_bd );
     int64_t extra = 2;
     int64_t size = inc*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -259,10 +259,10 @@ void test_memcpy_work( Params& params, bool run )
     if (verbose >= 1)
         printf( "cleanup\n" );
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -80,10 +80,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     int64_t ld = roundup( m, align );
     int64_t extra = 2;
     int64_t size = ld*(n + extra);
-    T* a_host = blas::device_malloc_pinned<T>( size, queue );
-    T* b_host = blas::device_malloc_pinned<T>( size, queue );
-    T* c_host = blas::device_malloc_pinned<T>( size, queue );
-    T* d_host = blas::device_malloc_pinned<T>( size, queue );
+    T* a_host = blas::host_malloc_pinned<T>( size, queue );
+    T* b_host = blas::host_malloc_pinned<T>( size, queue );
+    T* c_host = blas::host_malloc_pinned<T>( size, queue );
+    T* d_host = blas::host_malloc_pinned<T>( size, queue );
 
     // device specifics
     T* b_dev = blas::device_malloc<T>( size, queue );
@@ -234,10 +234,10 @@ void test_memcpy_2d_work( Params& params, bool run )
     params.error() = error;
     params.okay() = (error == 0);  // copy must be exact
 
-    blas::device_free_pinned( a_host, queue );
-    blas::device_free_pinned( b_host, queue );
-    blas::device_free_pinned( c_host, queue );
-    blas::device_free_pinned( d_host, queue );
+    blas::host_free_pinned( a_host, queue );
+    blas::host_free_pinned( b_host, queue );
+    blas::host_free_pinned( c_host, queue );
+    blas::host_free_pinned( d_host, queue );
     blas::device_free( b_dev, queue );
     blas::device_free( c_dev, queue );
 }

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -65,8 +65,8 @@ void test_nrm2_work( Params& params, bool run )
     real_t result = blas::nrm2( n, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < T >::nrm2( n );
-    double gbyte = Gbyte < T >::nrm2( n );
+    double gflop = blas::Gflop< T >::nrm2( n );
+    double gbyte = blas::Gbyte< T >::nrm2( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_nrm2_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -17,7 +17,6 @@ void test_nrm2_work( Params& params, bool run )
     using namespace blas;
     typedef T scalar_t;
     typedef real_type<T> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -54,7 +53,7 @@ void test_nrm2_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "x = " ); print_vector( n, x, incx );

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -14,9 +14,8 @@ template< typename T >
 void test_nrm2_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     typedef T scalar_t;
-    typedef real_type<T> real_t;
+    using real_t   = blas::real_type< T >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -99,8 +99,8 @@ void test_nrm2_device_work( Params& params, bool run )
         device_memcpy( &result_host, result, 1, queue );
     }
 
-    double gflop = Gflop<Tx>::nrm2( n );
-    double gbyte = Gbyte<Tx>::nrm2( n );
+    double gflop = blas::Gflop< Tx >::nrm2( n );
+    double gbyte = blas::Gbyte< Tx >::nrm2( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;
@@ -128,23 +128,23 @@ void test_nrm2_device_work( Params& params, bool run )
         }
 
         // relative forward error:
-        real_t error = std::abs( (result_cblas - result_host) 
-                           / (sqrt(n+1) * result_cblas) );          
+        real_t error = std::abs( (result_cblas - result_host)
+                           / (sqrt(n+1) * result_cblas) );
         params.error() = error;
 
 
-        if (verbose >= 2) {                                                     
-            printf( "err  = " ); print_vector( n, x, incx, "%9.2e" );           
-        }                                                                       
-                                                                                
-        // complex needs extra factor; see Higham, 2002, sec. 3.6.              
-        if (blas::is_complex<scalar_t>::value) {                                
-            error /= 2*sqrt(2);                                                 
-        }                                                                       
-                                                                                
-        real_t u = 0.5 * std::numeric_limits< real_t >::epsilon();              
-        params.error() = error;                                                 
-        params.okay() = (error < u);  
+        if (verbose >= 2) {
+            printf( "err  = " ); print_vector( n, x, incx, "%9.2e" );
+        }
+
+        // complex needs extra factor; see Higham, 2002, sec. 3.6.
+        if (blas::is_complex<scalar_t>::value) {
+            error /= 2*sqrt(2);
+        }
+
+        real_t u = 0.5 * std::numeric_limits< real_t >::epsilon();
+        params.error() = error;
+        params.okay() = (error < u);
     }
 
     delete[] x;

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -17,7 +17,6 @@ void test_nrm2_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<Tx> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     char mode       = params.pointer_mode();
@@ -83,7 +82,7 @@ void test_nrm2_device_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "n=%5lld, incx=%5lld, sizex=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );
@@ -125,7 +124,7 @@ void test_nrm2_device_work( Params& params, bool run )
         params.ref_gbytes() = gbyte / time;
 
         if (verbose >= 2) {
-            printf( "result0 = %3.2lld\n", (lld) result_cblas);
+            printf( "result0 = %.2e\n", result_cblas );
         }
 
         // relative forward error:

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -14,9 +14,8 @@ template< typename Tx >
 void test_nrm2_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<Tx> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using scalar_t = blas::scalar_type<Tx>;
+    using real_t   = blas::real_type<scalar_t>;
 
     // get & mark input values
     char mode       = params.pointer_mode();

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename Tx >
+template <typename Tx>
 void test_nrm2_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_rot.cc
+++ b/test/test_rot.cc
@@ -20,7 +20,6 @@ void test_rot_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<TX> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -81,8 +80,8 @@ void test_rot_work( Params& params, bool run )
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
                 real( s ), imag( s ), c, real( s*conj(s) ) + c*c,
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_rot.cc
+++ b/test/test_rot.cc
@@ -94,8 +94,8 @@ void test_rot_work( Params& params, bool run )
     blas::rot( n, x, incx, y, incy, c, s );
     time = get_wtime() - time;
 
-    double gflop = Gflop < TX >::dot( n );
-    double gbyte = Gbyte < TX >::dot( n );
+    double gflop = blas::Gflop< TX >::dot( n );
+    double gbyte = blas::Gbyte< TX >::dot( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_rot.cc
+++ b/test/test_rot.cc
@@ -18,8 +18,10 @@ template< typename TX, typename TS >
 void test_rot_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<TX> real_t;
+    using std::real;
+    using std::imag;
+    using blas::conj;
+    using real_t = blas::real_type< TX >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_rot.cc
+++ b/test/test_rot.cc
@@ -14,7 +14,7 @@
 // TX is data [x, y]
 // TS is for sine, which can be real (zdrot) or complex (zrot)
 // cosine is always real
-template< typename TX, typename TS >
+template <typename TX, typename TS>
 void test_rot_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_rotg.cc
+++ b/test/test_rotg.cc
@@ -9,7 +9,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_rotg_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_rotg.cc
+++ b/test/test_rotg.cc
@@ -13,9 +13,9 @@ template< typename T >
 void test_rotg_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using blas::real;
-    using blas::imag;
-    typedef blas::real_type<T> real_t;
+    using std::real;
+    using std::imag;
+    using real_t   = blas::real_type< T >;
 
     // get & mark input values
     int64_t n = params.dim.n();
@@ -37,7 +37,7 @@ void test_rotg_work( Params& params, bool run )
     std::vector<T> a( n ), aref( n ), a_in( n );
     std::vector<T> b( n ), bref( n ), b_in( n );
     std::vector<T> s( n ), sref( n );
-    std::vector< blas::real_type<T> > c( n ), cref( n );
+    std::vector< blas::real_type< T > > c( n ), cref( n );
 
     int64_t idist = 3;
     int iseed[4] = { 0, 0, 0, 1 };

--- a/test/test_rotg.cc
+++ b/test/test_rotg.cc
@@ -37,7 +37,7 @@ void test_rotg_work( Params& params, bool run )
     std::vector<T> a( n ), aref( n ), a_in( n );
     std::vector<T> b( n ), bref( n ), b_in( n );
     std::vector<T> s( n ), sref( n );
-    std::vector< blas::real_type< T > > c( n ), cref( n );
+    std::vector<real_t> c( n ), cref( n );
 
     int64_t idist = 3;
     int iseed[4] = { 0, 0, 0, 1 };

--- a/test/test_rotm.cc
+++ b/test/test_rotm.cc
@@ -17,7 +17,6 @@ void test_rotm_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<TX> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -74,8 +73,8 @@ void test_rotm_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_rotm.cc
+++ b/test/test_rotm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX >
+template <typename TX>
 void test_rotm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_rotm.cc
+++ b/test/test_rotm.cc
@@ -15,8 +15,7 @@ template< typename TX >
 void test_rotm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<TX> real_t;
+    using real_t   = blas::real_type< TX >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_rotm.cc
+++ b/test/test_rotm.cc
@@ -87,8 +87,8 @@ void test_rotm_work( Params& params, bool run )
     blas::rotm( n, x, incx, y, incy, p );
     time = get_wtime() - time;
 
-    double gflop = Gflop < TX >::dot( n );
-    double gbyte = Gbyte < TX >::dot( n );
+    double gflop = blas::Gflop< TX >::dot( n );
+    double gbyte = blas::Gbyte< TX >::dot( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_rotmg.cc
+++ b/test/test_rotmg.cc
@@ -9,7 +9,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_rotmg_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_rotmg.cc
+++ b/test/test_rotmg.cc
@@ -13,9 +13,9 @@ template< typename T >
 void test_rotmg_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using blas::real;
-    using blas::imag;
-    typedef blas::real_type<T> real_t;
+    using std::real;
+    using std::imag;
+    using real_t   = blas::real_type< T >;
 
     // get & mark input values
     int64_t n = params.dim.n();

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -69,8 +69,8 @@ void test_scal_work( Params& params, bool run )
     blas::scal( n, alpha, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < T >::scal( n );
-    double gbyte = Gbyte < T >::scal( n );
+    double gflop = blas::Gflop< T >::scal( n );
+    double gbyte = blas::Gbyte< T >::scal( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -14,8 +14,9 @@ template< typename T >
 void test_scal_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<T> real_t;
+    using std::real;
+    using std::imag;
+    using real_t = blas::real_type< T >;
 
     // get & mark input values
     T alpha         = params.alpha();

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_scal_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -16,7 +16,6 @@ void test_scal_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<T> real_t;
-    typedef long long lld;
 
     // get & mark input values
     T alpha         = params.alpha();
@@ -56,7 +55,7 @@ void test_scal_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -14,8 +14,9 @@ template< typename T >
 void test_scal_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef real_type<T> real_t;
+    using std::real;
+    using std::imag;
+    using real_t = blas::real_type< T >;
 
     // get & mark input values
     T alpha         = params.alpha();

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -85,8 +85,8 @@ void test_scal_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < T >::scal( n );
-    double gbyte = Gbyte < T >::scal( n );
+    double gflop = blas::Gflop< T >::scal( n );
+    double gbyte = blas::Gbyte< T >::scal( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -16,7 +16,6 @@ void test_scal_device_work( Params& params, bool run )
     using namespace testsweeper;
     using namespace blas;
     typedef real_type<T> real_t;
-    typedef long long lld;
 
     // get & mark input values
     T alpha         = params.alpha();
@@ -71,7 +70,7 @@ void test_scal_device_work( Params& params, bool run )
     if (verbose >= 1) {
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x );
+                llong( n ), llong( incx ), llong( size_x ) );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename T >
+template <typename T>
 void test_scal_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_schur_gemm.cc
+++ b/test/test_schur_gemm.cc
@@ -10,7 +10,7 @@
 
 
 // Copy A from LAPACK format on host to tile format on device.
-template< typename T >
+template <typename T>
 void copy_lapack_to_tile_format(
         int64_t m, int64_t n, int64_t mt, int64_t nt,
         T const*  A, int64_t ldA,
@@ -28,7 +28,7 @@ void copy_lapack_to_tile_format(
 }
 
 // Copy A from tile format on device to LAPACK format on host.
-template< typename T >
+template <typename T>
 void copy_tile_to_lapack_format(
         int64_t m, int64_t n, int64_t mt, int64_t nt,
         T const* dA, int64_t ld_tile,
@@ -46,7 +46,7 @@ void copy_tile_to_lapack_format(
 }
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_schur_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_schur_gemm.cc
+++ b/test/test_schur_gemm.cc
@@ -54,7 +54,6 @@ void test_schur_gemm_work( Params& params, bool run )
     using namespace blas::batch;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = Layout::ColMajor; //params.layout();

--- a/test/test_schur_gemm.cc
+++ b/test/test_schur_gemm.cc
@@ -50,10 +50,12 @@ template< typename TA, typename TB, typename TC >
 void test_schur_gemm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using namespace blas::batch;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Format;
     using scalar_t = blas::scalar_type< TA, TB, TC >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = Layout::ColMajor; //params.layout();

--- a/test/test_schur_gemm.cc
+++ b/test/test_schur_gemm.cc
@@ -214,7 +214,7 @@ void test_schur_gemm_work( Params& params, bool run )
     time_with_setup = t - time_with_setup;
     time = t - time;
 
-    double gflop = Gflop < scalar_t >::gemm( m_, n_, k_ );
+    double gflop = blas::Gflop< scalar_t >::gemm( m_, n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_swap.cc
+++ b/test/test_swap.cc
@@ -14,9 +14,8 @@ template< typename TX, typename TY >
 void test_swap_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using scalar_t = blas::scalar_type< TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n       = params.dim.n();

--- a/test/test_swap.cc
+++ b/test/test_swap.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_swap_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_swap.cc
+++ b/test/test_swap.cc
@@ -76,8 +76,8 @@ void test_swap_work( Params& params, bool run )
     blas::swap( n, x, incx, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::swap( n );
-    double gbyte = Gbyte < scalar_t >::swap( n );
+    double gflop = blas::Gflop< scalar_t >::swap( n );
+    double gbyte = blas::Gbyte< scalar_t >::swap( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_swap.cc
+++ b/test/test_swap.cc
@@ -17,7 +17,6 @@ void test_swap_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -63,8 +62,8 @@ void test_swap_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -14,9 +14,8 @@ template< typename TX, typename TY >
 void test_swap_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
     using scalar_t = blas::scalar_type< TX, TY >;
-    using real_t = blas::real_type< scalar_t >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     int64_t n          = params.dim.n();

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -96,8 +96,8 @@ void test_swap_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::swap( n );
-    double gbyte = Gbyte < scalar_t >::swap( n );
+    double gflop = blas::Gflop< scalar_t >::swap( n );
+    double gbyte = blas::Gbyte< scalar_t >::swap( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -10,7 +10,7 @@
 #include "print_matrix.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TX, typename TY >
+template <typename TX, typename TY>
 void test_swap_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -17,7 +17,6 @@ void test_swap_device_work( Params& params, bool run )
     using namespace blas;
     using scalar_t = blas::scalar_type< TX, TY >;
     using real_t = blas::real_type< scalar_t >;
-    typedef long long lld;
 
     // get & mark input values
     int64_t n          = params.dim.n();
@@ -82,8 +81,8 @@ void test_swap_device_work( Params& params, bool run )
         printf( "\n"
                 "x n=%5lld, inc=%5lld, size=%10lld\n"
                 "y n=%5lld, inc=%5lld, size=%10lld\n",
-                (lld) n, (lld) incx, (lld) size_x,
-                (lld) n, (lld) incy, (lld) size_y );
+                llong( n ), llong( incx ), llong( size_x ),
+                llong( n ), llong( incy ), llong( size_y ) );
     }
     if (verbose >= 2) {
         printf( "x    = " ); print_vector( n, x, incx );

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -111,7 +111,7 @@ void test_symm_work( Params& params, bool run )
                 alpha, A, lda, B, ldb, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::symm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::symm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_symm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -18,7 +18,6 @@ void test_symm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -92,9 +91,9 @@ void test_symm_work( Params& params, bool run )
                 "B  m=%5lld,  n=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  m=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 side2char(side), uplo2char(uplo),
-                (lld) An, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld)  n, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  m, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( An ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( n ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( m ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_symm.cc
+++ b/test/test_symm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_symm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_symm_device.cc
+++ b/test/test_symm_device.cc
@@ -133,7 +133,7 @@ void test_symm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::symm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::symm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);

--- a/test/test_symm_device.cc
+++ b/test/test_symm_device.cc
@@ -18,7 +18,6 @@ void test_symm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -113,9 +112,9 @@ void test_symm_device_work( Params& params, bool run )
                 "B  m=%5lld,  n=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  m=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 side2char(side), uplo2char(uplo),
-                (lld) An, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  m, (lld)  n, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  m, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( An ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( m ), llong( n ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( m ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_symm_device.cc
+++ b/test/test_symm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_symm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_symm_device.cc
+++ b/test/test_symm_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_symm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TB, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX, typename TY >
 void test_symv_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_symv_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -18,7 +18,6 @@ void test_symv_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -81,9 +80,9 @@ void test_symv_work( Params& params, bool run )
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -99,8 +99,8 @@ void test_symv_work( Params& params, bool run )
     blas::symv( layout, uplo, n, alpha, A, lda, x, incx, beta, y, incy );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::symv( n );
-    double gbyte = Gbyte < scalar_t >::symv( n );
+    double gflop = blas::Gflop< scalar_t >::symv( n );
+    double gbyte = blas::Gbyte< scalar_t >::symv( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -18,7 +18,6 @@ void test_syr_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -73,8 +72,8 @@ void test_syr_work( Params& params, bool run )
         printf( "\n"
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -88,8 +88,8 @@ void test_syr_work( Params& params, bool run )
     blas::syr( layout, uplo, n, alpha, x, incx, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syr( n );
-    double gbyte = Gbyte < scalar_t >::syr( n );
+    double gflop = blas::Gflop< scalar_t >::syr( n );
+    double gbyte = blas::Gbyte< scalar_t >::syr( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void test_syr_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX >
 void test_syr_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syr2.cc
+++ b/test/test_syr2.cc
@@ -18,7 +18,6 @@ void test_syr2_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX, TY> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -83,9 +82,9 @@ void test_syr2_work( Params& params, bool run )
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
                 "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm,
-                (lld) n, (lld) incy, (lld) size_y, Ynorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei;\n",

--- a/test/test_syr2.cc
+++ b/test/test_syr2.cc
@@ -100,8 +100,8 @@ void test_syr2_work( Params& params, bool run )
     blas::syr2( layout, uplo, n, alpha, x, incx, y, incy, A, lda );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syr2( n );
-    double gbyte = Gbyte < scalar_t >::syr2( n );
+    double gflop = blas::Gflop< scalar_t >::syr2( n );
+    double gbyte = blas::Gbyte< scalar_t >::syr2( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_syr2.cc
+++ b/test/test_syr2.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX, typename TY >
 void test_syr2_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX, TY> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syr2.cc
+++ b/test/test_syr2.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX, typename TY >
+template <typename TA, typename TX, typename TY>
 void test_syr2_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_syr2k_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -18,7 +18,6 @@ void test_syr2k_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -100,9 +99,9 @@ void test_syr2k_work( Params& params, bool run )
                 "B Bn=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Am, (lld) An, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Am ), llong( An ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_syr2k_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syr2k.cc
+++ b/test/test_syr2k.cc
@@ -119,7 +119,7 @@ void test_syr2k_work( Params& params, bool run )
                  alpha, A, lda, B, ldb, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syr2k( n, k );
+    double gflop = blas::Gflop< scalar_t >::syr2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_syr2k_device.cc
+++ b/test/test_syr2k_device.cc
@@ -141,7 +141,7 @@ void test_syr2k_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syr2k( n, k );
+    double gflop = blas::Gflop< scalar_t >::syr2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);

--- a/test/test_syr2k_device.cc
+++ b/test/test_syr2k_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB, typename TC >
+template <typename TA, typename TB, typename TC>
 void test_syr2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_syr2k_device.cc
+++ b/test/test_syr2k_device.cc
@@ -18,7 +18,6 @@ void test_syr2k_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -121,9 +120,9 @@ void test_syr2k_device_work( Params& params, bool run )
                 "B Bn=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld) Am, (lld) An, (lld) ldb, (lld) size_B, Bnorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( Am ), llong( An ), llong( ldb ), llong( size_B ), Bnorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_syr2k_device.cc
+++ b/test/test_syr2k_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB, typename TC >
 void test_syr2k_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -18,7 +18,6 @@ void test_syrk_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -86,8 +85,8 @@ void test_syrk_work( Params& params, bool run )
                 "A An=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 layout2char(layout), uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_syrk_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TC >
 void test_syrk_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syrk.cc
+++ b/test/test_syrk.cc
@@ -103,7 +103,7 @@ void test_syrk_work( Params& params, bool run )
                 alpha, A, lda, beta, C, ldc );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syrk( n, k );
+    double gflop = blas::Gflop< scalar_t >::syrk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_syrk_device.cc
+++ b/test/test_syrk_device.cc
@@ -122,7 +122,7 @@ void test_syrk_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::syrk( n, k );
+    double gflop = blas::Gflop< scalar_t >::syrk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);

--- a/test/test_syrk_device.cc
+++ b/test/test_syrk_device.cc
@@ -18,7 +18,6 @@ void test_syrk_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TC> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -104,8 +103,8 @@ void test_syrk_device_work( Params& params, bool run )
                 "A An=%5lld, An=%5lld, lda=%5lld, size=%10lld, norm %.2e\n"
                 "C  n=%5lld,  n=%5lld, ldc=%5lld, size=%10lld, norm %.2e\n",
                 layout2char(layout), uplo2char(uplo), op2char(trans),
-                (lld) Am, (lld) An, (lld) lda, (lld) size_A, Anorm,
-                (lld)  n, (lld)  n, (lld) ldc, (lld) size_C, Cnorm );
+                llong( Am ), llong( An ), llong( lda ), llong( size_A ), Anorm,
+                llong( n ), llong( n ), llong( ldc ), llong( size_C ), Cnorm );
     }
     if (verbose >= 2) {
         printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",

--- a/test/test_syrk_device.cc
+++ b/test/test_syrk_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TC >
 void test_syrk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TC> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using std::real;
+    using std::imag;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using scalar_t = blas::scalar_type< TA, TC >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_syrk_device.cc
+++ b/test/test_syrk_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TC >
+template <typename TA, typename TC>
 void test_syrk_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB >
 void test_trmm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -18,7 +18,6 @@ void test_trmm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -86,8 +85,8 @@ void test_trmm_work( Params& params, bool run )
         printf( "\n"
                 "A Am=%5lld, Am=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) Am, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm );
+                llong( Am ), llong( Am ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm );
     }
     if (verbose >= 2) {
         printf( "A = " ); print_matrix( Am, Am, A, lda );

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_trmm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trmm.cc
+++ b/test/test_trmm.cc
@@ -99,7 +99,7 @@ void test_trmm_work( Params& params, bool run )
     blas::trmm( layout, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trmm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::trmm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_trmm_device.cc
+++ b/test/test_trmm_device.cc
@@ -118,7 +118,7 @@ void test_trmm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trmm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::trmm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Bm, Bn, dB, ldb, B, ldb, queue);

--- a/test/test_trmm_device.cc
+++ b/test/test_trmm_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB >
 void test_trmm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trmm_device.cc
+++ b/test/test_trmm_device.cc
@@ -18,7 +18,6 @@ void test_trmm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -104,8 +103,8 @@ void test_trmm_device_work( Params& params, bool run )
         printf( "\n"
                 "A Am=%5lld, Am=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) Am, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm );
+                llong( Am ), llong( Am ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm );
     }
     if (verbose >= 2) {
         printf( "A = " ); print_matrix( Am, Am, A, lda );

--- a/test/test_trmm_device.cc
+++ b/test/test_trmm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_trmm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trmv.cc
+++ b/test/test_trmv.cc
@@ -91,8 +91,8 @@ void test_trmv_work( Params& params, bool run )
     blas::trmv( layout, uplo, trans, diag, n, A, lda, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trmv( n );
-    double gbyte = Gbyte < scalar_t >::trmv( n );
+    double gflop = blas::Gflop< scalar_t >::trmv( n );
+    double gbyte = blas::Gbyte< scalar_t >::trmv( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_trmv.cc
+++ b/test/test_trmv.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void test_trmv_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trmv.cc
+++ b/test/test_trmv.cc
@@ -15,9 +15,12 @@ template< typename TA, typename TX >
 void test_trmv_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trmv.cc
+++ b/test/test_trmv.cc
@@ -18,7 +18,6 @@ void test_trmv_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -78,8 +77,8 @@ void test_trmv_work( Params& params, bool run )
         printf( "\n"
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
     }
     if (verbose >= 2) {
         printf( "A = [];\n"    ); print_matrix( n, n, A, lda );

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -18,7 +18,6 @@ void test_trsm_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -117,8 +116,8 @@ void test_trsm_work( Params& params, bool run )
         printf( "\n"
                 "A Am=%5lld, Am=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) Am, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm );
+                llong( Am ), llong( Am ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm );
     }
     if (verbose >= 2) {
         printf( "A = " ); print_matrix( Am, Am, A, lda );

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -130,7 +130,7 @@ void test_trsm_work( Params& params, bool run )
     blas::trsm( layout, side, uplo, trans, diag, m, n, alpha, A, lda, B, ldb );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trsm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::trsm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
 

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB >
 void test_trsm_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TB >
+template <typename TA, typename TB>
 void test_trsm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -15,9 +15,13 @@ template< typename TA, typename TB >
 void test_trsm_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TB> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Side;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TB >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -18,7 +18,6 @@ void test_trsm_device_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TB> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -135,8 +134,8 @@ void test_trsm_device_work( Params& params, bool run )
         printf( "\n"
                 "A Am=%5lld, Am=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "B Bm=%5lld, Bn=%5lld, ldb=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) Am, (lld) Am, (lld) lda, (lld) size_A, Anorm,
-                (lld) Bm, (lld) Bn, (lld) ldb, (lld) size_B, Bnorm );
+                llong( Am ), llong( Am ), llong( lda ), llong( size_A ), Anorm,
+                llong( Bm ), llong( Bn ), llong( ldb ), llong( size_B ), Bnorm );
     }
     if (verbose >= 2) {
         printf( "A = " ); print_matrix( Am, Am, A, lda );

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -149,7 +149,7 @@ void test_trsm_device_work( Params& params, bool run )
     queue.sync();
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trsm( side, m, n );
+    double gflop = blas::Gflop< scalar_t >::trsm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
     blas::device_getmatrix(Bm, Bn, dB, ldb, B, ldb, queue);

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -123,8 +123,8 @@ void test_trsv_work( Params& params, bool run )
     blas::trsv( layout, uplo, trans, diag, n, A, lda, x, incx );
     time = get_wtime() - time;
 
-    double gflop = Gflop < scalar_t >::trsv( n );
-    double gbyte = Gbyte < scalar_t >::trsv( n );
+    double gflop = blas::Gflop< scalar_t >::trsv( n );
+    double gbyte = blas::Gbyte< scalar_t >::trsv( n );
     params.time()   = time * 1000;  // msec
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -17,9 +17,12 @@ void test_trsv_work( Params& params, bool run )
     #define A(i_, j_) (A + (i_) + (j_)*lda)
 
     using namespace testsweeper;
-    using namespace blas;
-    typedef scalar_type<TA, TX> scalar_t;
-    typedef real_type<scalar_t> real_t;
+    using blas::Uplo;
+    using blas::Op;
+    using blas::Layout;
+    using blas::Diag;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
 
     // get & mark input values
     blas::Layout layout = params.layout();

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -20,7 +20,6 @@ void test_trsv_work( Params& params, bool run )
     using namespace blas;
     typedef scalar_type<TA, TX> scalar_t;
     typedef real_type<scalar_t> real_t;
-    typedef long long lld;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -110,8 +109,8 @@ void test_trsv_work( Params& params, bool run )
         printf( "\n"
                 "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
                 "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
-                (lld) n, (lld) lda,  (lld) size_A, Anorm,
-                (lld) n, (lld) incx, (lld) size_x, Xnorm );
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
     }
     if (verbose >= 2) {
         printf( "A = "    ); print_matrix( n, n, A, lda );

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -11,7 +11,7 @@
 #include "check_gemm.hh"
 
 // -----------------------------------------------------------------------------
-template< typename TA, typename TX >
+template <typename TA, typename TX>
 void test_trsv_work( Params& params, bool run )
 {
     #define A(i_, j_) (A + (i_) + (j_)*lda)


### PR DESCRIPTION
This fixes various style issues, making them more consistent and closer to SLATE.
* Use more descriptive `llong` instead of `lld`.
* Remove `using namespace blas`. Best practice is to import just the few items needed (`using blas::Op`) and otherwise fully qualify references (`blas::Gflop<>( ... )`).
* Tweak spacing per style guide.

Each commit is one set of similar changes, so probably easiest to review by looking at each individual commit.

I will rebase this and fix any issues after merging in memcpy and host_alloc.