### PR TITLE
update include path for ROCm 5.2; fixes bitbucket issue #20

### DIFF
--- a/config/rocblas.cc
+++ b/config/rocblas.cc
@@ -8,7 +8,13 @@
 #endif
 
 #include <hip/hip_runtime.h>
-#include <rocblas.h>
+
+// Headers moved in ROCm 5.2
+#if HIP_VERSION >= 50200000
+    #include <rocblas/rocblas.h>
+#else
+    #include <rocblas.h>
+#endif
 
 #include <stdexcept>
 #include <cassert>

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -21,7 +21,13 @@
     #endif
 
     #include <hip/hip_runtime.h>
-    #include <rocblas.h>
+
+    // Headers moved in ROCm 5.2
+    #if HIP_VERSION >= 50200000
+        #include <rocblas/rocblas.h>
+    #else
+        #include <rocblas.h>
+    #endif
 
     // If we defined __HIP_PLATFORM_HCC__, undef it.
     #ifdef BLAS_HIP_PLATFORM_HCC


### PR DESCRIPTION
Resolves deprecated warnings. Cf. https://bitbucket.org/icl/blaspp/issues/20/rocm-520-deprecated-header