### PR TITLE
Cmake CUDA update

### DIFF
--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 maker=$1
 device=$2
@@ -7,24 +7,27 @@ mydir=$(dirname $0)
 source ${mydir}/setup_env.sh
 
 print "======================================== Build"
-make -j8
+make -j8 || exit 10
 
 print "======================================== Install"
-make -j8 install
+make -j8 install || exit 11
 ls -R ${top}/install
 
 print "======================================== Verify build"
-ldd_result=$(ldd test/tester)
+ldd_result=$(ldd test/tester) || exit 12
 echo "${ldd_result}"
 
 # Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
-    echo "${ldd_result}" | grep cublas || exit 1
+    echo "${ldd_result}" | grep cublas || exit 13
 
 elif [ "${device}" = "gpu_amd" ]; then
-    echo "${ldd_result}" | grep rocblas || exit 1
+    echo "${ldd_result}" | grep rocblas || exit 14
 
 else
     # CPU-only not linked with cublas or rocblas.
-    echo "${ldd_result}" | grep -P "cublas|rocblas" && exit 1
+    echo "${ldd_result}" | grep -P "cublas|rocblas" && exit 15
 fi
+
+print "======================================== Finished build"
+exit 0

--- a/.github/workflows/build.sh
+++ b/.github/workflows/build.sh
@@ -20,7 +20,11 @@ echo "${ldd_result}"
 # Verify that tester linked with cublas or rocblas as intended.
 if [ "${device}" = "gpu_nvidia" ]; then
     echo "${ldd_result}" | grep cublas || exit 1
-fi
-if [ "${device}" = "gpu_amd" ]; then
+
+elif [ "${device}" = "gpu_amd" ]; then
     echo "${ldd_result}" | grep rocblas || exit 1
+
+else
+    # CPU-only not linked with cublas or rocblas.
+    echo "${ldd_result}" | grep -P "cublas|rocblas" && exit 1
 fi

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 maker=$1
 device=$2
@@ -26,10 +26,15 @@ export color=no
 rm -rf ${top}/install
 if [ "${maker}" = "make" ]; then
     make distclean
-    make config CXXFLAGS="-Werror" prefix=${top}/install
+    make config CXXFLAGS="-Werror" prefix=${top}/install \
+         || exit 10
 fi
 if [ "${maker}" = "cmake" ]; then
     cmake -Dcolor=no -DCMAKE_CXX_FLAGS="-Werror" \
           -DCMAKE_INSTALL_PREFIX=${top}/install \
-          -Dgpu_backend=${gpu_backend} ..
+          -Dgpu_backend=${gpu_backend} .. \
+          || exit 11
 fi
+
+print "======================================== Finished configure"
+exit 0

--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -30,5 +30,6 @@ if [ "${maker}" = "make" ]; then
 fi
 if [ "${maker}" = "cmake" ]; then
     cmake -Dcolor=no -DCMAKE_CXX_FLAGS="-Werror" \
-          -DCMAKE_INSTALL_PREFIX=${top}/install ..
+          -DCMAKE_INSTALL_PREFIX=${top}/install \
+          -Dgpu_backend=${gpu_backend} ..
 fi

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -37,13 +37,18 @@ print "======================================== Load compiler"
 quiet module load gcc@7.3.0
 quiet module load intel-mkl
 
+# CMake will find CUDA in /usr/local/cuda, so need to explicitly set
+# gpu_backend.
+export gpu_backend=none
+
 if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     export CUDA_HOME=/usr/local/cuda/
     export PATH=${PATH}:${CUDA_HOME}/bin
     export CPATH=${CPATH}:${CUDA_HOME}/include
     export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
-    which nvcc
+    export gpu_backend=cuda
+    quiet which nvcc
     nvcc --version
 fi
 
@@ -53,14 +58,15 @@ if [ "${device}" = "gpu_amd" ]; then
     export CPATH=${CPATH}:/opt/rocm/include
     export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
     export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
-    which hipcc
+    export gpu_backend=hip
+    quiet which hipcc
     hipcc --version
 fi
 
 if [ "${maker}" = "cmake" ]; then
     print "======================================== Load cmake"
     quiet module load cmake
-    which cmake
+    quiet which cmake
     cmake --version
     cd build
 fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,13 @@
 #
 # CMake script for BLAS++ library.
 
-cmake_minimum_required( VERSION 3.15 )
+cmake_minimum_required( VERSION 3.17 )
 # 3.1  target_compile_features
 # 3.8  target_compile_features( cxx_std_11 )
 # 3.14 install( LIBRARY DESTINATION lib ) default
 # 3.15 $<$COMPILE_LANG_AND_ID  # optional
 # 3.15 message DEBUG, string REPEAT
+# 3.17 find_package( CUDAToolkit )
 
 project(
     blaspp
@@ -221,44 +222,36 @@ add_library(
 
 #-------------------------------------------------------------------------------
 # CUDA support.
+message( "" )
 set( blaspp_use_cuda false )  # output in blasppConfig.cmake.in
 if (gpu_backend MATCHES "^(auto|cuda)$")
-    include( CheckLanguage )
-    check_language( CUDA )
-    if (gpu_backend STREQUAL "cuda" AND NOT CMAKE_CUDA_COMPILER)
-        message( FATAL_ERROR "gpu_backend = ${gpu_backend}, but CUDA was not found")
+    message( STATUS "Looking for CUDA" )
+    if (gpu_backend STREQUAL "cuda")
+        find_package( CUDAToolkit REQUIRED )
+    else()
+        find_package( CUDAToolkit QUIET )
+    endif()
+    if (CUDAToolkit_FOUND)
+        set( gpu_backend "cuda" )
+        set( blaspp_defs_cuda_ "-DBLAS_HAVE_CUBLAS" )
+        set( blaspp_use_cuda true )
+
+        # Some platforms need these to be public libraries.
+        target_link_libraries(
+            blaspp PUBLIC CUDA::cudart CUDA::cublas )
+        message( STATUS "Building CUDA support" )
+    else()
+        message( STATUS "No CUDA support: CUDA not found" )
     endif()
 else()
-    message( STATUS "Skipping CUDA search. gpu_backend = ${gpu_backend}" )
-endif()
-if (CMAKE_CUDA_COMPILER)
-    enable_language( CUDA )
-
-    # todo: check for cuda 10.0+ and force newer CMake version - if possible
-
-    # CMake 3.17 adds find_package( CUDAToolkit )
-    # with CUDA::cudart and CUDA::cublas targets.
-    # For compatibility with older CMake, for now do search ourselves.
-    find_library( cudart_lib cudart ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} )
-    find_library( cublas_lib cublas ${CMAKE_CUDA_IMPLICIT_LINK_DIRECTORIES} )
-
-    set( blaspp_defs_cuda_ "-DBLAS_HAVE_CUBLAS" )
-    set( blaspp_use_cuda true )
-
-    # Some platforms need these to be public libraries.
-    target_link_libraries(
-        blaspp PUBLIC "${cudart_lib}" "${cublas_lib}" )
-    target_include_directories(
-        blaspp PUBLIC "${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES}" )
-    message( STATUS "Building CUDA support in BLAS++" )
-else()
-    message( STATUS "Not building CUDA support in BLAS++" )
+    message( STATUS "No CUDA support: gpu_backend = ${gpu_backend}" )
 endif()
 
 #-------------------------------------------------------------------------------
 # HIP/ROCm support.
+message( "" )
 set( blaspp_use_hip false )  # output in blasppConfig.cmake.in
-if (NOT CMAKE_CUDA_COMPILER
+if (NOT CUDAToolkit_FOUND
     AND gpu_backend MATCHES "^(auto|hip)$")
 
     message( STATUS "Looking for HIP/ROCm" )
@@ -267,22 +260,25 @@ if (NOT CMAKE_CUDA_COMPILER
     else()
         find_package( rocblas QUIET )
     endif()
-else()
-    message( STATUS "Skipping HIP/ROCm search. gpu_backend = ${gpu_backend}" )
-endif()
-if (rocblas_FOUND)
-    set( blaspp_defs_hip_ "-DBLAS_HAVE_ROCBLAS" )
-    set( blaspp_use_hip true )
+    if (rocblas_FOUND)
+        set( gpu_backend "hip" )
+        set( blaspp_defs_hip_ "-DBLAS_HAVE_ROCBLAS" )
+        set( blaspp_use_hip true )
 
-    # Some platforms need these to be public libraries.
-    target_link_libraries( blaspp PUBLIC roc::rocblas )
-    message( STATUS "Building HIP/ROCm support in BLAS++" )
+        # Some platforms need these to be public libraries.
+        target_link_libraries(
+            blaspp PUBLIC roc::rocblas )
+        message( STATUS "Building HIP/ROCm support" )
+    else()
+        message( STATUS "No HIP/ROCm support: ROCm not found" )
+    endif()
 else()
-    message( STATUS "Not building HIP/ROCm support in BLAS++" )
+    message( STATUS "No HIP/ROCm support: gpu_backend = ${gpu_backend}" )
 endif()
 
 #-------------------------------------------------------------------------------
 # Clean stale defines.h from Makefile-based build.
+message( "" )
 file( REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/include/blas/defines.h" )
 
 # Include directory.
@@ -337,6 +333,7 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Search for BLAS library.
+message( "" )
 if (BLA_VENDOR OR use_cmake_find_blas)
     message( DEBUG "Using CMake's FindBLAS" )
     find_package( BLAS )
@@ -384,9 +381,11 @@ if (true)
     )
 else()
     # Pass defines via compiler flags.
-    target_compile_definitions( blaspp PRIVATE ${blaspp_defines} )
+    target_compile_definitions(
+        blaspp PRIVATE ${blaspp_defines} )
 endif()
 
+# Export via blasppConfig.cmake
 set( blaspp_libraries "${BLAS_LIBRARIES};${openmp_lib}" CACHE INTERNAL "" )
 message( DEBUG "blaspp_libraries = '${blaspp_libraries}'" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,9 @@ set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
               auto cuda hip none )
 
+# After color.
+include( "cmake/util.cmake" )
+
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
     AND blaspp_is_project)
@@ -225,7 +228,7 @@ add_library(
 message( "" )
 set( blaspp_use_cuda false )  # output in blasppConfig.cmake.in
 if (gpu_backend MATCHES "^(auto|cuda)$")
-    message( STATUS "Looking for CUDA" )
+    message( STATUS "${bold}Looking for CUDA${not_bold} (gpu_backend = ${gpu_backend})" )
     if (gpu_backend STREQUAL "cuda")
         find_package( CUDAToolkit REQUIRED )
     else()
@@ -239,12 +242,12 @@ if (gpu_backend MATCHES "^(auto|cuda)$")
         # Some platforms need these to be public libraries.
         target_link_libraries(
             blaspp PUBLIC CUDA::cudart CUDA::cublas )
-        message( STATUS "Building CUDA support" )
+        message( STATUS "${blue}Building CUDA support${plain}" )
     else()
-        message( STATUS "No CUDA support: CUDA not found" )
+        message( STATUS "${red}No CUDA support: CUDA not found${plain}" )
     endif()
 else()
-    message( STATUS "No CUDA support: gpu_backend = ${gpu_backend}" )
+    message( STATUS "${red}No CUDA support: gpu_backend = ${gpu_backend}${plain}" )
 endif()
 
 #-------------------------------------------------------------------------------
@@ -254,7 +257,7 @@ set( blaspp_use_hip false )  # output in blasppConfig.cmake.in
 if (NOT CUDAToolkit_FOUND
     AND gpu_backend MATCHES "^(auto|hip)$")
 
-    message( STATUS "Looking for HIP/ROCm" )
+    message( STATUS "${bold}Looking for HIP/ROCm${not_bold} (gpu_backend = ${gpu_backend})" )
     if (gpu_backend STREQUAL "hip")
         find_package( rocblas REQUIRED )
     else()
@@ -268,12 +271,12 @@ if (NOT CUDAToolkit_FOUND
         # Some platforms need these to be public libraries.
         target_link_libraries(
             blaspp PUBLIC roc::rocblas )
-        message( STATUS "Building HIP/ROCm support" )
+        message( STATUS "${blue}Building HIP/ROCm support${plain}" )
     else()
-        message( STATUS "No HIP/ROCm support: ROCm not found" )
+        message( STATUS "${red}No HIP/ROCm support: ROCm not found${plain}" )
     endif()
 else()
-    message( STATUS "No HIP/ROCm support: gpu_backend = ${gpu_backend}" )
+    message( STATUS "${red}No HIP/ROCm support: gpu_backend = ${gpu_backend}${plain}" )
 endif()
 
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,28 +50,6 @@ set( gpu_backend "auto" CACHE STRING "GPU backend to use" )
 set_property( CACHE gpu_backend PROPERTY STRINGS
               auto cuda hip none )
 
-# Deprecated since 2021-04
-set( use_cuda "" CACHE STRING "Use CUDA, if available [deprecated: use gpu_backend]" )
-set( use_hip  "" CACHE STRING "Use HIP, if available [deprecated: use gpu_backend]" )
-
-if (use_cuda)
-    message( DEPRECATION "WARNING: `use_cuda=${use_cuda}` is deprecated; "
-                         "setting `gpu_backend = cuda`" )
-    set( gpu_backend "cuda" CACHE STRING "" FORCE )
-
-elseif (use_hip)
-    message( DEPRECATION "WARNING: `use_hip=${use_hip}` is deprecated; "
-                         "setting `gpu_backend = hip`" )
-    set( gpu_backend "hip" CACHE STRING "" FORCE )
-
-elseif (NOT use_cuda STREQUAL "" OR NOT use_hip STREQUAL "")
-    # use_cuda or use_hip is explicitly false; the other may be unset or false.
-    # If both are unset, they are ignored.
-    message( DEPRECATION "WARNING: `use_cuda=${use_cuda}` and `use_hip=${use_hip}` are deprecated; "
-                         "setting `gpu_backend = none`" )
-    set( gpu_backend "none" CACHE STRING "" FORCE )
-endif()
-
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
     AND blaspp_is_project)
@@ -145,8 +123,6 @@ build_tests            = ${build_tests}
 color                  = ${color}
 use_cmake_find_blas    = ${use_cmake_find_blas}
 gpu_backend            = ${gpu_backend}
-use_hip                = ${use_hip}
-use_cuda               = ${use_cuda}
 use_openmp             = ${use_openmp}
 blaspp_is_project      = ${blaspp_is_project}
 blaspp_                = ${blaspp_}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,11 @@ set_property( CACHE gpu_backend PROPERTY STRINGS
 # After color.
 include( "cmake/util.cmake" )
 
+# Recognize CTest's BUILD_TESTING flag. (Quotes required.)
+if (NOT "${BUILD_TESTING}" STREQUAL "")
+    set( build_tests "${BUILD_TESTING}" )
+endif()
+
 # Default prefix=/opt/slate
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT
     AND blaspp_is_project)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -231,9 +231,6 @@ not installed, you can point to its directory.
 Besides the Environment variables and Options listed above, additional
 options include:
 
-    use_cuda [deprecated; use gpu_backend]
-    use_hip  [deprecated; use gpu_backend]
-
     use_openmp
         Whether to use OpenMP, if available. One of:
         yes (default)

--- a/blasppConfig.cmake.in
+++ b/blasppConfig.cmake.in
@@ -9,6 +9,10 @@ if (blaspp_use_openmp)
     find_dependency( OpenMP )
 endif()
 
+if (blaspp_use_cuda)
+    find_dependency( CUDAToolkit )
+endif()
+
 if (blaspp_use_hip)
     find_dependency( rocblas )
 endif()

--- a/cmake/BLASFinder.cmake
+++ b/cmake/BLASFinder.cmake
@@ -56,7 +56,7 @@ set( blas_threaded_cached  ${blas_threaded}  CACHE INTERNAL "" )
 
 include( "cmake/util.cmake" )
 
-message( STATUS "Looking for BLAS libraries and options" )
+message( STATUS "${bold}Looking for BLAS libraries and options${not_bold} (blas = ${blas})" )
 
 #-------------------------------------------------------------------------------
 # Prints the BLAS_{name,libs}_lists.
@@ -441,7 +441,10 @@ foreach (blas_name IN LISTS blas_name_list)
     list( GET blas_libs_list ${i} blas_libs )
     math( EXPR i "${i}+1" )
 
-    message( "${bold}${blas_name}${not_bold}" )
+    if (i GREATER 1)
+        message( "" )
+    endif()
+    message( "${blas_name}" )
     message( "   libs:  ${blas_libs}" )
 
     # Strip to deal with default lib being space, " ".
@@ -525,7 +528,6 @@ foreach (blas_name IN LISTS blas_name_list)
             break()
         endif()
     endforeach()
-    message( "" )
 
     # Break loops as described above.
     if (BLAS_FOUND)
@@ -548,3 +550,4 @@ BLAS_FOUND          = '${BLAS_FOUND}'
 BLAS_LIBRARIES      = '${BLAS_LIBRARIES}'
 blaspp_defs_        = '${blaspp_defs_}'
 ")
+message( "" )

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -30,6 +30,9 @@ endif()
 function( pad_string input length output_variable )
     string( LENGTH "${input}" len )
     math( EXPR pad_len "${length} - ${len}" )
+    if (pad_len LESS 0)
+        set( pad_len 0 )
+    endif()
     string( REPEAT " " ${pad_len} pad )
     set( ${output_variable} "${input}${pad}" PARENT_SCOPE )
 endfunction()
@@ -53,4 +56,13 @@ function( debug_try_run msg compile_result compile_output run_result run_output 
     message( DEBUG "${msg}: compile_result '${compile_result}', run_result '${run_result}'" )
     message( TRACE "compile_output: '''\n${compile_output}'''" )
     message( TRACE "run_output: '''\n${run_output}'''" )
+endfunction()
+
+#-------------------------------------------------------------------------------
+# assert( condition )
+# Aborts if condition is not true.
+function( assert var )
+    if (NOT ${var})
+        message( FATAL_ERROR "\n${red}Assertion failed: ${var} (value is '${${var}}')${default_color}\n" )
+    endif()
 endfunction()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,11 +15,12 @@ if (NOT lapack_found_)
 endif()
 
 # Search for TestSweeper library, if not already included (e.g., in SLATE).
-message( STATUS "Checking for TestSweeper library" )
+message( STATUS "${bold}Checking for TestSweeper library${not_bold}" )
 if (NOT TARGET testsweeper)
     find_package( testsweeper QUIET )
     if (testsweeper_FOUND)
-        message( "   Found TestSweeper library: ${testsweeper_DIR}" )
+        message( "   ${blue}Found TestSweeper library: ${testsweeper_DIR}${plain}" )
+        message( "" )
     else()
         set( url "https://github.com/icl-utk-edu/testsweeper" )
         set( tag "2021.04.00" )
@@ -34,7 +35,7 @@ if (NOT TARGET testsweeper)
         message( "" )
     endif()
 else()
-    message( "   TestSweeper already included" )
+    message( "   ${blue}TestSweeper already included${plain}" )
 endif()
 
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
- Use newer find_package( CUDAToolkit ).
- If using CUDA, export find_dependency. Addresses https://bitbucket.org/icl/blaspp/issues/23. The example smoke tests compile fine before and after, so I can't actually replicate a problem.
- Tweak CMake output.
- CMake finds CUDA in /usr/local/cuda even if it isn't "loaded", so needed to update the CI build scripts to set gpu_target explicitly. Added a check that the CPU-only version does not link with cublas or rocblas, which required changing how errors are handled in the CI build scripts.