### PR TITLE
Cmake link with lapack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set_property( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
 
 # Provide menu of options.
 set( BLA_VENDOR "" CACHE STRING
-     "BLAS Vendor for use in CMake's FindBLAS. If empty, use BLAS++ search. Some obsolete options are omitted here." )
+     "BLAS Vendor for use in CMake's FindBLAS / FindLAPACK. If empty, use BLAS++ search. Some obsolete options are omitted here." )
 set_property(
     CACHE BLA_VENDOR PROPERTY STRINGS
     "" All Goto OpenBLAS FLAME ATLAS IBMESSL
@@ -118,6 +118,15 @@ set_property(
     CACHE blas_threaded PROPERTY STRINGS
     "auto" "true" "false" )
 
+#-----------------------------------
+# LAPACK options
+# todo: FLAME, others?
+set( lapack "auto" CACHE STRING
+     "LAPACK library to search for. Often, LAPACK is included in the BLAS library (e.g., -lopenblas contains both)." )
+set_property(
+    CACHE lapack PROPERTY STRINGS
+    "auto" "generic" )
+
 message( DEBUG "Settings:
 CMAKE_VERSION          = ${CMAKE_VERSION}
 CMAKE_INSTALL_PREFIX   = ${CMAKE_INSTALL_PREFIX}
@@ -128,6 +137,7 @@ blas                   = ${blas}
 blas_fortran           = ${blas_fortran}
 blas_int               = ${blas_int}
 blas_threaded          = ${blas_threaded}
+lapack                 = ${lapack}
 build_tests            = ${build_tests}
 color                  = ${color}
 use_cmake_find_blas    = ${use_cmake_find_blas}
@@ -361,6 +371,31 @@ include( "cmake/BLASConfig.cmake" )
 # Only tester needs cblas, but always config it so LAPACK++ tester can use it.
 include( "cmake/CBLASConfig.cmake" )
 
+# Export via blasppConfig.cmake
+# Needed for finding LAPACK.
+set( blaspp_libraries "${BLAS_LIBRARIES};${openmp_lib}" CACHE INTERNAL "" )
+message( DEBUG "blaspp_libraries = '${blaspp_libraries}'" )
+
+#-------------------------------------------------------------------------------
+# Search for LAPACK library.
+message( "" )
+if (BLA_VENDOR OR use_cmake_find_blas)
+    message( DEBUG "Using CMake's FindLAPACK" )
+    find_package( LAPACK )
+else()
+    message( DEBUG "Using LAPACKFinder" )
+    include( "cmake/LAPACKFinder.cmake" )
+endif()
+
+if (NOT LAPACK_FOUND)
+    message( "For [cz]rot, [cz]syr, and [cz]symv, BLAS++ requires a LAPACK library and none was found."
+             " Ensure that it is accessible in environment variables"
+             " $CPATH, $LIBRARY_PATH, and $LD_LIBRARY_PATH." )
+endif()
+
+# BLAS++ doesn't need LAPACKConfig.cmake, which checks version, XBLAS, LAPACKE.
+
+#-------------------------------------------------------------------------------
 # Cache blaspp_defs_ that was built in BLASFinder, BLASConfig, CBLASConfig.
 set( blaspp_defs_ "${blaspp_defs_}"
      CACHE INTERNAL "Constants defined for BLAS" )
@@ -393,9 +428,12 @@ else()
         blaspp PRIVATE ${blaspp_defines} )
 endif()
 
-# Export via blasppConfig.cmake
-set( blaspp_libraries "${BLAS_LIBRARIES};${openmp_lib}" CACHE INTERNAL "" )
-message( DEBUG "blaspp_libraries = '${blaspp_libraries}'" )
+if (LAPACK_LIBRARIES)
+    # Update BLAS libraries with LAPACK libraries.
+    # Export via blasppConfig.cmake
+    set( blaspp_libraries "${BLAS_LIBRARIES};${LAPACK_LIBRARIES};${openmp_lib}" CACHE INTERNAL "" )
+    message( DEBUG "blaspp_libraries = '${blaspp_libraries}'" )
+endif()
 
 # blaspp_libraries could be private, but then if an application directly
 # calls blas, cblas, lapack, lapacke, mkl, essl, etc., it would need to

--- a/cmake/LAPACKFinder.cmake
+++ b/cmake/LAPACKFinder.cmake
@@ -3,29 +3,131 @@
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-# Check if this file has already been run with these settings.
-if (DEFINED lapack_config_cache
-    AND "${lapack_config_cache}" STREQUAL "${BLAS_LIBRARIES}")
+# Convert to list, as lapack_libs is later, to match cached value.
+string( REGEX REPLACE "([^ ])( +|\\\;)" "\\1;"    LAPACK_LIBRARIES "${LAPACK_LIBRARIES}" )
+string( REGEX REPLACE "-framework;" "-framework " LAPACK_LIBRARIES "${LAPACK_LIBRARIES}" )
 
-    message( DEBUG "LAPACK config already done for '${BLAS_LIBRARIES}'" )
+message( DEBUG "LAPACK_LIBRARIES '${LAPACK_LIBRARIES}'"        )
+message( DEBUG "  cached         '${lapack_libraries_cached}'" )
+message( DEBUG "lapack           '${lapack}'"                  )
+message( DEBUG "  cached         '${lapack_cached}'"           )
+message( DEBUG "" )
+
+#-----------------------------------
+# Check if this file has already been run with these settings.
+if (LAPACK_LIBRARIES
+    AND NOT "${lapack_libraries_cached}" STREQUAL "${LAPACK_LIBRARIES}")
+    # Ignore lapack if LAPACK_LIBRARIES changes.
+    # Set to empty, rather than unset, so when cmake is invoked again
+    # they don't force a search.
+    message( DEBUG "clear lapack" )
+    set( lapack "" CACHE INTERNAL "" )
+elseif (NOT ("${lapack_cached}" STREQUAL "${lapack}"))
+    # Ignore LAPACK_LIBRARIES if lapack* changed.
+    message( DEBUG "unset LAPACK_LIBRARIES" )
+    set( LAPACK_LIBRARIES "" CACHE INTERNAL "" )
+else()
+    message( DEBUG "LAPACK search already done for
+    lapack           = ${lapack}
+    LAPACK_LIBRARIES = ${LAPACK_LIBRARIES}" )
     return()
 endif()
-set( lapack_config_cache "${BLAS_LIBRARIES}" CACHE INTERNAL "" )
+
+set( lapack_libraries_cached ${LAPACK_LIBRARIES} CACHE INTERNAL "" )  # updated later
+set( lapack_cached           ${lapack}           CACHE INTERNAL "" )
 
 include( "cmake/util.cmake" )
 
-set( lib_list ";-llapack" )
-message( DEBUG "lib_list ${lib_list}" )
+message( STATUS "${bold}Looking for LAPACK libraries and options${not_bold} (lapack = ${lapack})" )
 
-foreach (lib IN LISTS lib_list)
-    message( STATUS "Checking for LAPACK library ${lib}" )
+#-------------------------------------------------------------------------------
+# Parse options: LAPACK_LIBRARIES, lapack.
 
+#---------------------------------------- LAPACK_LIBRARIES
+if (LAPACK_LIBRARIES)
+    set( test_lapack_libraries true )
+endif()
+
+#---------------------------------------- lapack
+string( TOLOWER "${lapack}" lapack_ )
+
+if ("${lapack_}" MATCHES "auto")
+    set( test_all true )
+endif()
+
+if ("${lapack_}" MATCHES "default")
+    set( test_default true )
+endif()
+
+if ("${lapack_}" MATCHES "generic")
+    set( test_generic true )
+endif()
+
+message( DEBUG "
+LAPACK_LIBRARIES      = '${LAPACK_LIBRARIES}'
+lapack                = '${lapack}'
+lapack_               = '${lapack_}'
+test_lapack_libraries = '${test_lapack_libraries}'
+test_default          = '${test_default}'
+test_generic          = '${test_generic}'
+test_all              = '${test_all}'")
+
+#-------------------------------------------------------------------------------
+# Build list of libraries to check.
+# todo: add flame?
+# todo: LAPACK_?(ROOT|DIR)
+
+set( lapack_libs_list "" )
+
+#---------------------------------------- LAPACK_LIBRARIES
+if (test_lapack_libraries)
+    # Escape ; semi-colons so we can append it as one item to a list.
+    string( REPLACE ";" "\\;" LAPACK_LIBRARIES_ESC "${LAPACK_LIBRARIES}" )
+    message( DEBUG "LAPACK_LIBRARIES ${LAPACK_LIBRARIES}" )
+    message( DEBUG "   =>          ${LAPACK_LIBRARIES_ESC}" )
+    list( APPEND lapack_libs_list "${LAPACK_LIBRARIES_ESC}" )
+endif()
+
+#---------------------------------------- default (in BLAS library)
+if (test_all OR test_default)
+    list( APPEND lapack_libs_list " " )
+endif()
+
+#---------------------------------------- generic -llapack
+if (test_all OR test_generic)
+    list( APPEND lapack_libs_list "-llapack" )
+endif()
+
+message( DEBUG "lapack_libs_list ${lapack_libs_list}" )
+
+#-------------------------------------------------------------------------------
+# Check each LAPACK library.
+# BLAS++ needs only a limited subset of LAPACK, so check for potrf (Cholesky).
+# LAPACK++ checks for pstrf (Cholesky with pivoting) to make sure it is
+# a complete LAPACK library, since some BLAS libraries (ESSL, ATLAS)
+# contain only an optimized subset of LAPACK routines.
+
+unset( LAPACK_FOUND CACHE )
+unset( lapackpp_defs_ CACHE )
+
+foreach (lapack_libs IN LISTS lapack_libs_list)
+    if ("${lapack_libs}" MATCHES "^ *$")
+        set( label "   In BLAS library" )
+    else()
+        set( label "   ${lapack_libs}" )
+    endif()
+    pad_string( "${label}" 50 label )
+
+    # Try to link and run LAPACK routine with the library.
     try_run(
         run_result compile_result ${CMAKE_CURRENT_BINARY_DIR}
         SOURCES
             "${CMAKE_CURRENT_SOURCE_DIR}/config/lapack_potrf.cc"
         LINK_LIBRARIES
-            ${lib} ${BLAS_LIBRARIES} ${openmp_lib} # not "..." quoted; screws up OpenMP
+            # Use blaspp_libraries instead of blaspp, when SLATE includes
+            # blaspp and lapackpp, so the blaspp library doesn't exist yet.
+            # Not "quoted"; screws up OpenMP.
+            ${lapack_libs} ${blaspp_libraries}
         COMPILE_DEFINITIONS
             ${blaspp_defines}
         COMPILE_OUTPUT_VARIABLE
@@ -36,21 +138,39 @@ foreach (lib IN LISTS lib_list)
     debug_try_run( "lapack_potrf.cc" "${compile_result}" "${compile_output}"
                                      "${run_result}" "${run_output}" )
 
-    if (compile_result AND "${run_output}" MATCHES "ok")
-        set( lapack_libraries_ "${lib}" CACHE INTERNAL "" )
-        set( lapack_found_ true CACHE INTERNAL "" )
+    if (NOT compile_result)
+        message( "${label} ${red} no (didn't link: routine not found)${plain}" )
+    elseif ("${run_result}" EQUAL 0 AND "${run_output}" MATCHES "ok")
+        # If it runs (exits 0), we're done, so break loop.
+        message( "${label} ${blue} yes${plain}" )
+
+        set( LAPACK_FOUND true CACHE INTERNAL "" )
+        string( STRIP "${lapack_libs}" lapack_libs )
+        set( LAPACK_LIBRARIES "${lapack_libs}" CACHE STRING "" FORCE )
+        list( APPEND lapackpp_defs_ "-DLAPACK_HAVE_LAPACK" )
         break()
+    else()
+        message( "${label} ${red} no (didn't run: int mismatch, etc.)${plain}" )
     endif()
 endforeach()
 
+# Update to found LAPACK library.
+set( lapack_libraries_cached ${LAPACK_LIBRARIES} CACHE INTERNAL "" )
+
 #-------------------------------------------------------------------------------
-if (lapack_found_)
-    message( "${blue}   Found LAPACK library ${lapack_libraries_}${plain}" )
+if (LAPACK_FOUND)
+    if (NOT LAPACK_LIBRARIES)
+        message( "${blue}   Found LAPACK library in BLAS library${plain}" )
+    else()
+        message( "${blue}   Found LAPACK library: ${LAPACK_LIBRARIES}${plain}" )
+    endif()
 else()
-    message( "${red}   LAPACK library not found. Tester cannot be built.${plain}" )
+    message( "${red}   LAPACK library not found.${plain}" )
 endif()
 
 message( DEBUG "
-lapack_found_       = '${lapack_found_}'
-lapack_libraries_   = '${lapack_libraries_}'
+LAPACK_FOUND        = '${LAPACK_FOUND}'
+LAPACK_LIBRARIES    = '${LAPACK_LIBRARIES}'
+lapackpp_defs_        = '${lapackpp_defs_}'
 ")
+message( "" )

--- a/include/blas/wrappers.hh
+++ b/include/blas/wrappers.hh
@@ -199,7 +199,9 @@ void rot(
     double s );
 
 /// @ingroup rot
-// real cosine, real sine
+/// real cosine, real sine
+/// Applies a real Givens rotation (e.g., in real tridiagonal eig)
+/// to a complex matrix (e.g., complex eigenvectors).
 void rot(
     int64_t n,
     std::complex<float> *x, int64_t incx,
@@ -208,13 +210,37 @@ void rot(
     float s );
 
 /// @ingroup rot
-// real cosine, real sine
+/// real cosine, real sine
+/// Applies a real Givens rotation (e.g., in real tridiagonal eig)
+/// to a complex matrix (e.g., complex eigenvectors).
 void rot(
     int64_t n,
     std::complex<double> *x, int64_t incx,
     std::complex<double> *y, int64_t incy,
     double c,
     double s );
+
+/// @ingroup rot
+/// real cosine, complex sine
+/// Applies a complex Givens rotation to a complex matrix
+/// (e.g., in complex GMRES).
+void rot(
+    int64_t n,
+    std::complex<float> *x, int64_t incx,
+    std::complex<float> *y, int64_t incy,
+    float c,
+    std::complex<float> s );
+
+/// @ingroup rot
+/// real cosine, complex sine
+/// Applies a complex Givens rotation to a complex matrix
+/// (e.g., in complex GMRES).
+void rot(
+    int64_t n,
+    std::complex<double> *x, int64_t incx,
+    std::complex<double> *y, int64_t incy,
+    double c,
+    std::complex<double> s );
 
 // -----------------------------------------------------------------------------
 /// @ingroup rotg

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,7 +9,7 @@ if (NOT blaspp_cblas_found)
     return()
 endif()
 
-if (NOT lapack_found_)
+if (NOT LAPACK_FOUND)
     message( WARNING "LAPACK not found; tester cannot be built." )
     return()
 endif()


### PR DESCRIPTION
BLAS++ wraps `rot`. Unfortunately, technically some variants are in BLAS (srot, drot, csrot, zdrot), while some are in LAPACK (crot, zrot).
```
lapack> pfind 'rot.f$'
./BLAS/SRC/csrot.f
./BLAS/SRC/drot.f
./BLAS/SRC/srot.f
./BLAS/SRC/zdrot.f
./SRC/crot.f
./SRC/zrot.f
```
This isn't a problem for libraries that include both BLAS and LAPACK, like OpenBLAS, Intel MKL, Cray LibSci. But it can be an issue for libraries like BLIS that don't include LAPACK. (IBM ESSL includes `[cz]rot`, though it doesn't include all of LAPACK.)

The solution here is to find and link with the LAPACK library. The configure.py / Makefile build already does this.

A similar issue affects `[cz]symv` and `[cz]syr`. The previous solution for those was to put them in LAPACK++, but still in the blas namespace, which is really ugly.

Cf. https://bitbucket.org/icl/blaspp/pull-requests/44
which proposed removing `[cz]rot` wrappers.

Also add `rot` wrapper prototypes for `[cz]rot`.