### PR TITLE
Cmake cross-compiling

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,8 +55,10 @@ BLAS++ specific options include (all values are case insensitive):
     blas_int
         BLAS integer size to search for. One or more of:
         auto            search for both sizes (default)
-        int             32-bit int (LP64 model)
+        int32           32-bit int (LP64 model)
         int64           64-bit int (ILP64 model)
+        When cross-compiling, this cannot be auto-detected, so the user
+        must specify int32 or int64.
 
     blas_threaded
         Whether to search for multi-threaded or sequential BLAS.
@@ -305,3 +307,22 @@ To debug the build, set `VERBOSE`:
 
     # in build directory, after running cmake
     make VERBOSE=1
+
+### Cross-compiling
+
+For cross-compiling, there are several additional options that the user
+must determine and specify manually, since CMake cannot auto-detect
+them. See also `blas_int` above.
+
+    blas_complex_return
+        How zdotc, etc., returns a complex value. This is required when
+        cross-compiling -- there is no default value. One of:
+        return          As return value. This is the GNU gfortran convention.
+        argument        As a hidden complex output argument. This is the
+                        Intel ifort convention.
+
+    blas_return_float_f2c
+        Whether sdot, etc., returns float (usual convention) or double
+        (f2c convention used in CLAPACK and macOS Accelerate).
+        no              returns float. Default except for macOS Accelerate.
+        yes             returns double. Default for macOS Accelerate.

--- a/cmake/BLASConfig.cmake
+++ b/cmake/BLASConfig.cmake
@@ -3,16 +3,20 @@
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-# Check if this file has already been run with these settings.
+include( "cmake/util.cmake" )
+
+# Check if this file has already been run with these settings (see bottom).
+set( run_ true )
 if (DEFINED blas_config_cache
     AND "${blas_config_cache}" STREQUAL "${BLAS_LIBRARIES}")
 
     message( DEBUG "BLAS config already done for '${BLAS_LIBRARIES}'" )
-    return()
+    set( run_ false )
 endif()
-set( blas_config_cache "${BLAS_LIBRARIES}" CACHE INTERNAL "" )
 
-include( "cmake/util.cmake" )
+#===============================================================================
+# Matching endif at bottom.
+if (run_)
 
 #-------------------------------------------------------------------------------
 # Search to identify library and get version. Besides providing the
@@ -294,6 +298,12 @@ else()
         list( APPEND blaspp_defs_ "-DBLAS_HAVE_F2C" )
     endif()
 endif()
+
+endif() # run_
+#===============================================================================
+
+# Mark as already run (see top).
+set( blas_config_cache "${BLAS_LIBRARIES}" CACHE INTERNAL "" )
 
 #-------------------------------------------------------------------------------
 message( DEBUG "

--- a/cmake/BLASConfig.cmake
+++ b/cmake/BLASConfig.cmake
@@ -29,6 +29,9 @@ if (NOT found)
         message( "${blue}   Accelerate framework${plain}" )
         list( APPEND blaspp_defs_ "-DBLAS_HAVE_ACCELERATE" )
         set( found true )
+        if (NOT DEFINED blas_return_float_f2c)
+            set( blas_return_float_f2c true )
+        endif()
     endif()
 endif()
 
@@ -47,6 +50,12 @@ if (NOT found)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, if it links, assume the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: mkl" )
+        set( run_result "0" CACHE STRING "" FORCE )
+        set( run_output "MKL_VERSION=unknown" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "mkl_version.cc" "${compile_result}" "${compile_output}"
                                     "${run_result}" "${run_output}" )
 
@@ -72,6 +81,12 @@ if (NOT found)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, if it links, assume the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: essl" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ESSL_VERSION=unknown" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "essl_version.cc" "${compile_result}" "${compile_output}"
                                      "${run_result}" "${run_output}" )
 
@@ -97,6 +112,12 @@ if (NOT found)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, if it links, assume the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: openblas" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "OPENBLAS_VERSION=unknown" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "openblas_version.cc" "${compile_result}" "${compile_output}"
                                          "${run_result}" "${run_output}" )
 
@@ -122,6 +143,12 @@ if (NOT found)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, if it links, assume the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: acml" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ACML_VERSION=unknown" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "acml_version.cc" "${compile_result}" "${compile_output}"
                                      "${run_result}" "${run_output}" )
 
@@ -151,6 +178,20 @@ try_run(
     RUN_OUTPUT_VARIABLE
         run_output
 )
+# For cross-compiling, user must provide extra info.
+if (CMAKE_CROSSCOMPILING AND compile_result)
+    message( DEBUG "cross: blas_complex_return = '${blas_complex_return}'" )
+    set( run_result "0"  CACHE STRING "" FORCE )
+    if (blas_complex_return STREQUAL "return")
+        set( run_output "ok" CACHE STRING "" FORCE )
+    elseif (blas_complex_return STREQUAL "argument")
+        set( run_output "failed" CACHE STRING "" FORCE )
+    else()
+        message( FATAL_ERROR " ${red}When cross-compiling, one must define either\n"
+                 " `blas_complex_return=return` (GNU gfortran convention) or\n"
+                 " `blas_complex_return=argument` (Intel ifort convention).${plain}" )
+    endif()
+endif()
 debug_try_run( "return_complex.cc" "${compile_result}" "${compile_output}"
                                    "${run_result}" "${run_output}" )
 
@@ -171,6 +212,13 @@ else()
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, user must provide extra info.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: blas_complex_return = '${blas_complex_return}' (2)" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ok" CACHE STRING "" FORCE )
+        assert( blas_complex_return STREQUAL "argument" )  # follows from above
+    endif()
     debug_try_run( "return_complex_argument.cc"
                    "${compile_result}" "${compile_output}"
                    "${run_result}" "${run_output}" )
@@ -199,6 +247,17 @@ try_run(
     RUN_OUTPUT_VARIABLE
         run_output
 )
+# For cross-compiling, assume the run is okay unless the user provides
+# ${blas_return_float_f2c}.
+if (CMAKE_CROSSCOMPILING AND compile_result)
+    message( DEBUG "cross: not blas_return_float_f2c = '${blas_return_float_f2c}'" )
+    set( run_result "0"  CACHE STRING "" FORCE )
+    if (blas_return_float_f2c)
+        set( run_output "failed" CACHE STRING "" FORCE )
+    else()
+        set( run_output "ok" CACHE STRING "" FORCE )
+    endif()
+endif()
 debug_try_run( "return_float.cc" "${compile_result}" "${compile_output}"
                                  "${run_result}" "${run_output}" )
 
@@ -220,6 +279,13 @@ else()
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, user must provide ${blas_return_float_f2c}.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: blas_return_float_f2c = ${blas_return_float_f2c}" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ok" CACHE STRING "" FORCE )
+        assert( blas_return_float_f2c )  # follows from above
+    endif()
     debug_try_run( "return_float_f2c.cc" "${compile_result}" "${compile_output}"
                                          "${run_result}" "${run_output}" )
 

--- a/cmake/BLASFinder.cmake
+++ b/cmake/BLASFinder.cmake
@@ -19,8 +19,13 @@ message( DEBUG "blas_threaded  '${blas_threaded}'"         )
 message( DEBUG "  cached       '${blas_threaded_cached}'"  )
 message( DEBUG "" )
 
+include( "cmake/util.cmake" )
+
+message( STATUS "${bold}Looking for BLAS libraries and options${not_bold} (blas = ${blas})" )
+
 #-----------------------------------
-# Check if this file has already been run with these settings.
+# Check if this file has already been run with these settings (see bottom).
+set( run_ true )
 if (BLAS_LIBRARIES
     AND NOT "${blas_libraries_cached}" STREQUAL "${BLAS_LIBRARIES}")
     # Ignore blas, etc. if BLAS_LIBRARIES changes.
@@ -45,18 +50,12 @@ else()
     blas_int       = ${blas_int}
     blas_threaded  = ${blas_threaded}
     BLAS_LIBRARIES = ${BLAS_LIBRARIES}" )
-    return()
+    set( run_ false )
 endif()
 
-set( blas_libraries_cached ${BLAS_LIBRARIES} CACHE INTERNAL "" )  # updated later
-set( blas_cached           ${blas}           CACHE INTERNAL "" )
-set( blas_fortran_cached   ${blas_fortran}   CACHE INTERNAL "" )
-set( blas_int_cached       ${blas_int}       CACHE INTERNAL "" )
-set( blas_threaded_cached  ${blas_threaded}  CACHE INTERNAL "" )
-
-include( "cmake/util.cmake" )
-
-message( STATUS "${bold}Looking for BLAS libraries and options${not_bold} (blas = ${blas})" )
+#===============================================================================
+# Matching endif at bottom.
+if (run_)
 
 #-------------------------------------------------------------------------------
 # Prints the BLAS_{name,libs}_lists.
@@ -546,8 +545,15 @@ foreach (blas_name IN LISTS blas_name_list)
     endif()
 endforeach()
 
-# Update to found BLAS library.
+endif() # run_
+#===============================================================================
+
+# Mark as already run (see top).
 set( blas_libraries_cached ${BLAS_LIBRARIES} CACHE INTERNAL "" )
+set( blas_cached           ${blas}           CACHE INTERNAL "" )
+set( blas_fortran_cached   ${blas_fortran}   CACHE INTERNAL "" )
+set( blas_int_cached       ${blas_int}       CACHE INTERNAL "" )
+set( blas_threaded_cached  ${blas_threaded}  CACHE INTERNAL "" )
 
 #-------------------------------------------------------------------------------
 if (BLAS_FOUND)

--- a/cmake/CBLASConfig.cmake
+++ b/cmake/CBLASConfig.cmake
@@ -53,6 +53,12 @@ foreach (lib IN LISTS lib_list)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, assume if it links, the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: cblas" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ok" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "cblas.cc" "${compile_result}" "${compile_output}"
                               "${run_result}" "${run_output}" )
 

--- a/cmake/CBLASConfig.cmake
+++ b/cmake/CBLASConfig.cmake
@@ -3,16 +3,20 @@
 # This program is free software: you can redistribute it and/or modify it under
 # the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-# Check if this file has already been run with these settings.
+include( "cmake/util.cmake" )
+
+# Check if this file has already been run with these settings (see bottom).
+set( run_ true )
 if (DEFINED cblas_config_cache
     AND "${cblas_config_cache}" STREQUAL "${BLAS_LIBRARIES}")
 
     message( DEBUG "CBLAS config already done for '${BLAS_LIBRARIES}'" )
-    return()
+    set( run_ false )
 endif()
-set( cblas_config_cache "${BLAS_LIBRARIES}" CACHE INTERNAL "" )
 
-include( "cmake/util.cmake" )
+#===============================================================================
+# Matching endif at bottom.
+if (run_)
 
 #----------------------------------------
 # Apple puts cblas.h in weird places. If we can't find it,
@@ -69,6 +73,12 @@ foreach (lib IN LISTS lib_list)
         break()
     endif()
 endforeach()
+
+endif() # run_
+#===============================================================================
+
+# Mark as already run (see top).
+set( cblas_config_cache "${BLAS_LIBRARIES}" CACHE INTERNAL "" )
 
 #-------------------------------------------------------------------------------
 if (blaspp_cblas_found)

--- a/cmake/LAPACKFinder.cmake
+++ b/cmake/LAPACKFinder.cmake
@@ -13,8 +13,13 @@ message( DEBUG "lapack           '${lapack}'"                  )
 message( DEBUG "  cached         '${lapack_cached}'"           )
 message( DEBUG "" )
 
+include( "cmake/util.cmake" )
+
+message( STATUS "${bold}Looking for LAPACK libraries and options${not_bold} (lapack = ${lapack})" )
+
 #-----------------------------------
 # Check if this file has already been run with these settings.
+set( run_ true )
 if (LAPACK_LIBRARIES
     AND NOT "${lapack_libraries_cached}" STREQUAL "${LAPACK_LIBRARIES}")
     # Ignore lapack if LAPACK_LIBRARIES changes.
@@ -30,15 +35,12 @@ else()
     message( DEBUG "LAPACK search already done for
     lapack           = ${lapack}
     LAPACK_LIBRARIES = ${LAPACK_LIBRARIES}" )
-    return()
+    set( run_ false )
 endif()
 
-set( lapack_libraries_cached ${LAPACK_LIBRARIES} CACHE INTERNAL "" )  # updated later
-set( lapack_cached           ${lapack}           CACHE INTERNAL "" )
-
-include( "cmake/util.cmake" )
-
-message( STATUS "${bold}Looking for LAPACK libraries and options${not_bold} (lapack = ${lapack})" )
+#===============================================================================
+# Matching endif at bottom.
+if (run_)
 
 #-------------------------------------------------------------------------------
 # Parse options: LAPACK_LIBRARIES, lapack.
@@ -160,8 +162,12 @@ foreach (lapack_libs IN LISTS lapack_libs_list)
     endif()
 endforeach()
 
-# Update to found LAPACK library.
+endif() # run_
+#===============================================================================
+
+# Mark as already run (see top).
 set( lapack_libraries_cached ${LAPACK_LIBRARIES} CACHE INTERNAL "" )
+set( lapack_cached           ${lapack}           CACHE INTERNAL "" )
 
 #-------------------------------------------------------------------------------
 if (LAPACK_FOUND)

--- a/cmake/LAPACKFinder.cmake
+++ b/cmake/LAPACKFinder.cmake
@@ -135,6 +135,12 @@ foreach (lapack_libs IN LISTS lapack_libs_list)
         RUN_OUTPUT_VARIABLE
             run_output
     )
+    # For cross-compiling, if it links, assume the run is okay.
+    if (CMAKE_CROSSCOMPILING AND compile_result)
+        message( DEBUG "cross: lapack_potrf" )
+        set( run_result "0"  CACHE STRING "" FORCE )
+        set( run_output "ok" CACHE STRING "" FORCE )
+    endif()
     debug_try_run( "lapack_potrf.cc" "${compile_result}" "${compile_output}"
                                      "${run_result}" "${run_output}" )
 


### PR DESCRIPTION
When cross-compiling, BLAS++ needs some extra information because it can't effectively probe the system. It can detect link-time differences (gemm_ vs. gemm vs. GEMM) but not run-time differences (int32 vs. int64, how complex is returned). [Per CMake's docs](https://cmake.org/cmake/help/latest/command/try_run.html?highlight=try_run#behavior-when-cross-compiling), when cross-compiling, `try_run` compiles but doesn't run the code. This PR sets `run_output` and `run_result` to values _as if_ it had run, with certain assumptions. The user must supply several items that cannot be probed (see INSTALL.md):
- `blas_int`
- `blas_complex_return`
- [optional] `blas_return_float_f2c`. This will be set automatically for macOS Accelerate, the only currently affected BLAS library in common use.

This PR also fixes an issue that include files would cache their inputs at the top, and skip re-running if the input matched the cache value. Thus if there was failure, re-running CMake would skip re-running the file, hiding the failure. Instead, cache values at the _end_ of the file, so they aren't cached if there is a failure.