### PR TITLE
test: change 2-line headers to 1-line headers and adjust widths

### DIFF
--- a/test/test.cc
+++ b/test/test.cc
@@ -21,6 +21,12 @@ using testsweeper::ansi_bold;
 using testsweeper::ansi_red;
 using testsweeper::ansi_normal;
 
+const double no_data = testsweeper::no_data_flag;
+
+const ParamType PT_Value  = ParamType::Value;
+const ParamType PT_List   = ParamType::List;
+const ParamType PT_Output = ParamType::Output;
+
 // -----------------------------------------------------------------------------
 // each section must have a corresponding entry in section_names
 enum Section {
@@ -233,35 +239,39 @@ Params::Params():
 
     // ----- output parameters
     // min, max are ignored
-    //          name,                w, p, type,              default,               min, max, help
-    error     ( "BLAS++\nerror",    11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error" ),
-    error2    ( "BLAS++\nerror2",   11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error 2" ),
-    error3    ( "BLAS++\nerror3",   11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "numerical error 3" ),
-    time      ( "BLAS++\ntime (s)", 11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution" ),
-    gflops    ( "BLAS++\nGflop/s",  11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate" ),
-    gbytes    ( "BLAS++\nGbyte/s",  11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate" ),
+    //          name,            w, p, type,      default, min, max, help
+    // error: %8.2e allows 9.99e-99
+    error     ( "error",         8, 2, PT_Output, no_data, 0, 0, "numerical error" ),
+    error2    ( "error2",        8, 2, PT_Output, no_data, 0, 0, "numerical error 2" ),
+    error3    ( "error3",        8, 2, PT_Output, no_data, 0, 0, "numerical error 3" ),
 
-    time2     ( "time2 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (2)" ),
-    gflops2   ( "Gflop2/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (2)" ),
-    gbytes2   ( "Gbyte2/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (2)" ),
+    // time:    %9.3f allows 99999.999 s = 2.9 days (ref headers need %12)
+    // gflops: %12.3f allows 99999999.999 Gflop/s = 100 Pflop/s
+    time      ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution" ),
+    gflops    ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate" ),
+    gbytes    ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate" ),
 
-    time3     ( "time3 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (3)" ),
-    gflops3   ( "Gflop3/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (3)" ),
-    gbytes3   ( "Gbyte3/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (3)" ),
+    time2     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (2)" ),
+    gflops2   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (2)" ),
+    gbytes2   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (2)" ),
 
-    time4     ( "time4 (s)",        11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "time to solution (4)" ),
-    gflops4   ( "Gflop4/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gflop/s rate (4)" ),
-    gbytes4   ( "Gbyte4/s",         11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "Gbyte/s rate (4)" ),
+    time3     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (3)" ),
+    gflops3   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (3)" ),
+    gbytes3   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (3)" ),
 
-    ref_time  ( "Ref.\ntime (s)",   11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference time to solution" ),
-    ref_gflops( "Ref.\nGflop/s",    11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference Gflop/s rate" ),
-    ref_gbytes( "Ref.\nGbyte/s",    11, 4, ParamType::Output, testsweeper::no_data_flag,   0,   0, "reference Gbyte/s rate" ),
+    time4     ( "time (s)",      9, 3, PT_Output, no_data, 0, 0, "time to solution (4)" ),
+    gflops4   ( "gflop/s",      12, 3, PT_Output, no_data, 0, 0, "Gflop/s rate (4)" ),
+    gbytes4   ( "gbyte/s",      12, 3, PT_Output, no_data, 0, 0, "Gbyte/s rate (4)" ),
+
+    ref_time  ( "ref time (s)", 12, 3, PT_Output, no_data, 0, 0, "reference time to solution" ),
+    ref_gflops( "ref gflop/s",  12, 3, PT_Output, no_data, 0, 0, "reference Gflop/s rate" ),
+    ref_gbytes( "ref gbyte/s",  12, 3, PT_Output, no_data, 0, 0, "reference Gbyte/s rate" ),
 
     // default -1 means "no check"
     okay      ( "status",              6,    ParamType::Output,  -1,   0,   0, "success indicator" ),
     msg       ( "",       1, ParamType::Output,  "",           "error message" )
 {
-    // set header different than command line prefix 
+    // set header different than command line prefix
     pointer_mode.name("ptr", "pointer-mode");
 
     // mark standard set of output fields as used

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -30,8 +30,9 @@ void test_asum_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -35,8 +35,9 @@ void test_axpy_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -35,8 +35,9 @@ void test_axpy_device_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_copy.cc
+++ b/test/test_copy.cc
@@ -32,8 +32,9 @@ void test_copy_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -32,8 +32,9 @@ void test_copy_device_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_dot.cc
+++ b/test/test_dot.cc
@@ -34,8 +34,9 @@ void test_dot_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_dotu.cc
+++ b/test/test_dotu.cc
@@ -34,8 +34,9 @@ void test_dotu_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_gemv.cc
+++ b/test/test_gemv.cc
@@ -42,8 +42,9 @@ void test_gemv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;
@@ -129,7 +130,7 @@ void test_gemv_work( Params& params, bool run )
                     alpha, A, lda, x, incx, beta, yref, incy );
         time = get_wtime() - time;
 
-        params.ref_time()   = time * 1000;  // msec
+        params.ref_time()   = time; // * 1000;  // msec
         params.ref_gflops() = gflop / time;
         params.ref_gbytes() = gbyte / time;
 

--- a/test/test_ger.cc
+++ b/test/test_ger.cc
@@ -39,8 +39,9 @@ void test_ger_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_geru.cc
+++ b/test/test_geru.cc
@@ -39,8 +39,9 @@ void test_geru_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_hemv.cc
+++ b/test/test_hemv.cc
@@ -41,8 +41,9 @@ void test_hemv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_her.cc
+++ b/test/test_her.cc
@@ -37,8 +37,9 @@ void test_her_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_her2.cc
+++ b/test/test_her2.cc
@@ -40,8 +40,9 @@ void test_her2_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -29,8 +29,9 @@ void test_iamax_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -30,8 +30,9 @@ void test_nrm2_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -36,8 +36,9 @@ void test_nrm2_device_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_rot.cc
+++ b/test/test_rot.cc
@@ -37,8 +37,9 @@ void test_rot_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_rotg.cc
+++ b/test/test_rotg.cc
@@ -27,8 +27,9 @@ void test_rotg_work( Params& params, bool run )
     params.error3();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_rotm.cc
+++ b/test/test_rotm.cc
@@ -31,8 +31,9 @@ void test_rotm_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_rotmg.cc
+++ b/test/test_rotmg.cc
@@ -24,8 +24,9 @@ void test_rotmg_work( Params& params, bool run )
     params.ref_time();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -32,8 +32,9 @@ void test_scal_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -33,8 +33,9 @@ void test_scal_device_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_swap.cc
+++ b/test/test_swap.cc
@@ -31,8 +31,9 @@ void test_swap_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -32,8 +32,9 @@ void test_swap_device_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_symv.cc
+++ b/test/test_symv.cc
@@ -41,8 +41,9 @@ void test_symv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_syr.cc
+++ b/test/test_syr.cc
@@ -39,8 +39,9 @@ void test_syr_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_syr2.cc
+++ b/test/test_syr2.cc
@@ -40,8 +40,9 @@ void test_syr2_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_trmv.cc
+++ b/test/test_trmv.cc
@@ -40,8 +40,9 @@ void test_trmv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -42,8 +42,9 @@ void test_trsv_work( Params& params, bool run )
     params.ref_gbytes();
 
     // adjust header to msec
-    params.time.name( "BLAS++\ntime (ms)" );
-    params.ref_time.name( "Ref.\ntime (ms)" );
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
 
     if (! run)
         return;


### PR DESCRIPTION
TestSweeper allows headers to be 2 lines, which is nice for compact output, but harder to parse, e.g., by pandas. Use 1 line headers for ease of parsing. Also match SLATE's header names. Note it's fine to have space in a header. Columns are separated by 2 spaces, which is how we split data for pandas.