### PR TITLE
Blaspp deprecate functions

### DIFF
--- a/config/onemkl.cc
+++ b/config/onemkl.cc
@@ -3,8 +3,8 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <CL/sycl/detail/cl.h>
-#include <CL/sycl.hpp>
+#include <sycl/detail/cl.h>
+#include <sycl.hpp>
 #include <oneapi/mkl.hpp>
 
 #include <stdexcept>
@@ -23,7 +23,7 @@ int main()
     double D[] = { 40, 61, 21, 28 };
 
     // enumerate devices
-    std::vector< cl::sycl::device > devices;
+    std::vector< sycl::device > devices;
     auto platforms = sycl::platform::get_platforms();
     for (auto& platform : platforms) {
         auto all_devices = platform.get_devices();
@@ -41,9 +41,9 @@ int main()
     sycl::queue queue( devices[0] );
 
     double *dA, *dB, *dC;
-    dA = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
-    dB = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
-    dC = (double*) cl::sycl::malloc_shared( n*n*sizeof(double), queue );
+    dA = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
+    dB = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
+    dC = (double*) sycl::malloc_shared( n*n*sizeof(double), queue );
 
     // dA = A, dB = B, dC = c
     queue.memcpy( dA, A, n*n*sizeof(double) );

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -305,7 +305,7 @@ inline const char* device_error_string( rocblas_status error )
     // blaspp aborts on device errors
     #if defined(BLAS_HAVE_ONEMKL)
         #define blas_dev_call( error ) \
-            do {
+            do { \
                 try { \
                     error; \
                 } \
@@ -320,7 +320,7 @@ inline const char* device_error_string( rocblas_status error )
                 catch (...) { \
                     blas::internal::abort_if( true, __func__, \
                                               "%s", "unknown exception" ); \
-                }
+                } \
             } while(0)
 
     #else
@@ -337,7 +337,7 @@ inline const char* device_error_string( rocblas_status error )
     // blaspp throws device errors (default)
     #if defined(BLAS_HAVE_ONEMKL)
         #define blas_dev_call( error ) \
-            do {
+            do { \
                 try { \
                         error; \
                 } \
@@ -352,7 +352,7 @@ inline const char* device_error_string( rocblas_status error )
                 catch (...) { \
                     blas::internal::throw_if( true, \
                                               "unknown exception", __func__ ); \
-                }
+                } \
             } while(0)
 
     #else

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -36,8 +36,8 @@
     #endif
 
 #elif defined(BLAS_HAVE_ONEMKL)
-    #include <CL/sycl/detail/cl.h>  // For CL version
-    #include <CL/sycl.hpp>
+    #include <sycl/detail/cl.h>  // For CL version
+    #include <sycl.hpp>
 
 #endif
 
@@ -166,8 +166,8 @@ public:
         hipStream_t    stream()        const { return *current_stream_; }
         rocblas_handle handle()        const { return handle_; }
     #elif defined(BLAS_HAVE_ONEMKL)
-        cl::sycl::device sycl_device() const { return sycl_device_; }
-        cl::sycl::queue  stream()      const { return *default_stream_; }
+        sycl::device sycl_device() const { return sycl_device_; }
+        sycl::queue  stream()      const { return *default_stream_; }
     #endif
 
 private:
@@ -224,14 +224,14 @@ private:
     #elif defined(BLAS_HAVE_ONEMKL)
         // in addition to the integer device_ member, we need
         // the sycl device id
-        cl::sycl::device  sycl_device_;
+        sycl::device  sycl_device_;
 
         // default sycl queue for this blas queue
-        cl::sycl::queue *default_stream_;
-        cl::sycl::event  default_event_;
+        sycl::queue *default_stream_;
+        sycl::event  default_event_;
 
         // pointer to current stream (default or fork mode)
-        cl::sycl::queue *current_stream_;
+        sycl::queue *current_stream_;
 
     #else
         // pointer to current stream (default or fork mode)
@@ -309,7 +309,7 @@ inline const char* device_error_string( rocblas_status error )
                 try { \
                     error; \
                 } \
-                catch (cl::sycl::exception const& e) { \
+                catch (sycl::exception const& e) { \
                     blas::internal::abort_if( true, __func__, \
                                               "%s", e.what() ); \
                 } \
@@ -341,7 +341,7 @@ inline const char* device_error_string( rocblas_status error )
                 try { \
                         error; \
                 } \
-                catch (cl::sycl::exception const& e) { \
+                catch (sycl::exception const& e) { \
                     blas::internal::throw_if( true, \
                                               e.what(), __func__ ); \
                 } \
@@ -380,7 +380,7 @@ void get_device( blas::Device *device );
 
 device_blas_int get_device_count();
 #ifdef BLAS_HAVE_ONEMKL
-void enumerate_devices(std::vector<cl::sycl::device> &devices);
+void enumerate_devices(std::vector<sycl::device> &devices);
 #endif
 
 // -----------------------------------------------------------------------------
@@ -478,7 +478,7 @@ T* device_malloc(
 
     #elif defined(BLAS_HAVE_ONEMKL)
         blas_dev_call(
-            ptr = (T*)cl::sycl::malloc_shared( nelements*sizeof(T), queue.stream() ) );
+            ptr = (T*)sycl::malloc_shared( nelements*sizeof(T), queue.stream() ) );
 
     #else
         throw blas::Error( "device BLAS not available", __func__ );
@@ -550,7 +550,7 @@ T* host_malloc_pinned(
 
     #elif defined(BLAS_HAVE_ONEMKL)
         blas_dev_call(
-            ptr = (T*)cl::sycl::malloc_host( nelements*sizeof(T), queue.stream() ) );
+            ptr = (T*)sycl::malloc_host( nelements*sizeof(T), queue.stream() ) );
 
     #else
         throw blas::Error( "device BLAS not available", __func__ );

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -369,8 +369,15 @@ inline const char* device_error_string( rocblas_status error )
 
 // -----------------------------------------------------------------------------
 // set/get device functions
+[[deprecated("use blas::Queues& with all blaspp calls")]]
 void set_device( blas::Device device );
+
+// private, internal routine; sets device for cuda, rocm; nothing for onemkl
+void internal_set_device( blas::Device device );
+
+[[deprecated("use blas::Queues& with all blaspp calls")]]
 void get_device( blas::Device *device );
+
 device_blas_int get_device_count();
 #ifdef BLAS_HAVE_ONEMKL
 void enumerate_devices(std::vector<cl::sycl::device> &devices);
@@ -380,21 +387,25 @@ void enumerate_devices(std::vector<cl::sycl::device> &devices);
 // memory functions
 
 /// @deprecated: use device_free( ptr, queue ).
+[[deprecated("use device_free( ptr, queue )")]]
 void device_free( void* ptr );
 
 void device_free( void* ptr, blas::Queue &queue );
 
 /// @deprecated: use host_free_pinned( ptr, queue ).
+// todo: does this really need to be deprecated
 void host_free_pinned( void* ptr );
 
 void host_free_pinned( void* ptr, blas::Queue &queue );
 
 /// @deprecated: use host_free_pinned( ptr, queue ).
+[[deprecated("use device_free_pinned( ptr, queue )")]]
 inline void device_free_pinned( void* ptr ) {
     host_free_pinned( ptr );
 }
 
 /// @deprecated: use host_free_pinned( ptr, queue ).
+[[deprecated("use host_free_pinned( ptr, queue )")]]
 inline void device_free_pinned( void* ptr, blas::Queue &queue )
 {
     host_free_pinned( ptr, queue );
@@ -412,6 +423,7 @@ inline void device_free_pinned( void* ptr, blas::Queue &queue )
 /// in SYCL, this doesn't work since there is no concept of a current device.
 ///
 template <typename T>
+[[deprecated("use device_malloc( nelements, queue )")]]
 T* device_malloc(
     int64_t nelements)
 {
@@ -455,12 +467,12 @@ T* device_malloc(
 
     T* ptr = nullptr;
     #ifdef BLAS_HAVE_CUBLAS
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
                 cudaMalloc( (void**)&ptr, nelements * sizeof(T) ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
                 hipMalloc( (void**)&ptr, nelements * sizeof(T) ) );
 
@@ -482,6 +494,7 @@ T* device_malloc(
 /// in SYCL, this doesn't work since there is no concept of a current device.
 ///
 template <typename T>
+[[deprecated("use host_malloc_pinned( nelements, queue )")]]
 T* device_malloc_pinned(
     int64_t nelements)
 {
@@ -549,6 +562,7 @@ T* host_malloc_pinned(
 /// @deprecated: use host_malloc_pinned( nelements, queue ).
 ///
 template <typename T>
+[[deprecated("device_malloc_pinned( nelements, queue )")]]
 T* device_malloc_pinned(
     int64_t nelements, blas::Queue &queue )
 {
@@ -579,14 +593,14 @@ void device_memset(
     blas_error_if( nelements < 0 );
 
     #ifdef BLAS_HAVE_CUBLAS
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             cudaMemsetAsync(
                 ptr, value,
                 nelements * sizeof(T), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             hipMemsetAsync(
                 ptr, value,
@@ -622,14 +636,14 @@ void device_memcpy(
     blas_error_if( nelements < 0 );
 
     #ifdef BLAS_HAVE_CUBLAS
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             cudaMemcpyAsync(
                 dst, src, sizeof(T)*nelements,
                 memcpy2cuda(kind), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             hipMemcpyAsync(
                 dst, src, sizeof(T)*nelements,
@@ -697,7 +711,7 @@ void device_memcpy_2d(
     blas_error_if( src_pitch < width );
 
     #ifdef BLAS_HAVE_CUBLAS
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             cudaMemcpy2DAsync(
                 dst, sizeof(T)*dst_pitch,
@@ -705,7 +719,7 @@ void device_memcpy_2d(
                 sizeof(T)*width, height, memcpy2cuda(kind), queue.stream() ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             hipMemcpy2DAsync(
                 dst, sizeof(T)*dst_pitch,
@@ -877,6 +891,7 @@ void device_copy_matrix(
 /// @see device_copy_vector
 ///
 template <typename T>
+[[deprecated("recommend device_copy_vector( n, any_src, inc_src, any_dst, inc_dst, queue )")]]
 void device_setvector(
     int64_t n,
     T const* src_host, int64_t inc_src,
@@ -895,6 +910,7 @@ void device_setvector(
 /// @see device_copy_vector
 ///
 template <typename T>
+[[deprecated("recommend device_copy_vector( n, any_src, inc_src, any_dst, inc_dst, queue )")]]
 void device_getvector(
     int64_t n,
     T const* src_dev,  int64_t inc_src,
@@ -913,6 +929,7 @@ void device_getvector(
 /// @see device_copy_matrix
 ///
 template <typename T>
+[[deprecated("recommend device_copy_matrix( m, n, any_src, ld_src, any_dst, ld_dst, queue )")]]
 void device_setmatrix(
     int64_t m, int64_t n,
     T const* src_host, int64_t ld_src,
@@ -931,6 +948,7 @@ void device_setmatrix(
 /// @see device_copy_matrix
 ///
 template <typename T>
+[[deprecated("recommend device_copy_matrix( m, n, any_src, ld_src, any_dst, ld_dst, queue )")]]
 void device_getmatrix(
     int64_t m, int64_t n,
     T const* src_dev,  int64_t ld_src,

--- a/src/device_axpy.cc
+++ b/src/device_axpy.cc
@@ -37,9 +37,7 @@ void blas::axpy(
     device_blas_int incdx_ = (device_blas_int) incdx;
     device_blas_int incdy_ = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::saxpy( queue, n_, alpha, dx, incdx_, dy, incdy_ );
 }
@@ -69,9 +67,7 @@ void blas::axpy(
     device_blas_int incdx_ = (device_blas_int) incdx;
     device_blas_int incdy_ = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::daxpy( queue, n_, alpha, dx, incdx_, dy, incdy_ );
 }
@@ -101,9 +97,7 @@ void blas::axpy(
     device_blas_int incdx_ = (device_blas_int) incdx;
     device_blas_int incdy_ = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::caxpy( queue, n_, alpha, dx, incdx_, dy, incdy_ );
 }
@@ -133,9 +127,7 @@ void blas::axpy(
     device_blas_int incdx_ = (device_blas_int) incdx;
     device_blas_int incdy_ = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::zaxpy( queue, n_, alpha, dx, incdx_, dy, incdy_ );
 }

--- a/src/device_batch_gemm.cc
+++ b/src/device_batch_gemm.cc
@@ -60,9 +60,8 @@ void gemm(
                           Carray.size() == batch &&
                           lddc.size()   == 1 );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
+
     if (fixed_size) {
         // call the vendor routine
         blas::Op        transA_ = transA[0];
@@ -84,11 +83,11 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Aarray[ib], 1, dAarray, 1, queue );
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Barray[ib], 1, dBarray, 1, queue );
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Carray[ib], 1, dCarray, 1, queue );
 
             if (layout == Layout::RowMajor) {
@@ -181,9 +180,7 @@ void gemm(
                           Carray.size() == batch &&
                           lddc.size()   == 1 );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (fixed_size) {
         // call the vendor routine
         blas::Op        transA_ = transA[0];
@@ -205,11 +202,11 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Aarray[ib], 1, dAarray, 1, queue );
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Barray[ib], 1, dBarray, 1, queue );
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Carray[ib], 1, dCarray, 1, queue );
 
             if (layout == Layout::RowMajor) {
@@ -303,9 +300,7 @@ void gemm(
                           Carray.size() == batch &&
                           lddc.size()   == 1 );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (fixed_size) {
         // call the vendor routine
         blas::Op        transA_ = transA[0];
@@ -327,13 +322,13 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector< std::complex<float> *>(
+            device_copy_vector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Aarray[ib], 1,
                 dAarray, 1, queue );
-            device_setvector< std::complex<float> *>(
+            device_copy_vector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Barray[ib], 1,
                 dBarray, 1, queue );
-            device_setvector< std::complex<float> *>(
+            device_copy_vector< std::complex<float> *>(
                 ibatch, (std::complex<float>**) &Carray[ib], 1,
                 dCarray, 1, queue );
 
@@ -428,9 +423,7 @@ void gemm(
                           Carray.size() == batch &&
                           lddc.size()   == 1 );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (fixed_size) {
         // call the vendor routine
         blas::Op        transA_ = transA[0];
@@ -452,11 +445,11 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector< std::complex<double> *>(
+            device_copy_vector< std::complex<double> *>(
                 ibatch, (std::complex<double>**) &Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector< std::complex<double> *>(
+            device_copy_vector< std::complex<double> *>(
                 ibatch, (std::complex<double>**) &Barray[ib], 1, dBarray, 1, queue);
-            device_setvector< std::complex<double> *>(
+            device_copy_vector< std::complex<double> *>(
                 ibatch, (std::complex<double>**) &Carray[ib], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
@@ -567,9 +560,7 @@ void gemm(
     }
 
     // set device
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     float **dAarray, **dBarray, **dCarray;
     size_t batch_limit = queue.get_batch_limit();
@@ -600,11 +591,11 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<float*>(
+            device_copy_vector<float*>(
                 ibatch, (float**) &Carray[ processed+ib ], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
@@ -697,9 +688,7 @@ void gemm(
     }
 
     // set device
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     double **dAarray, **dBarray, **dCarray;
     size_t batch_limit = queue.get_batch_limit();
@@ -730,11 +719,11 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Aarray[ processed+ib ], 1, dAarray, 1, queue);
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Barray[ processed+ib ], 1, dBarray, 1, queue);
-            device_setvector<double*>(
+            device_copy_vector<double*>(
                 ibatch, (double**) &Carray[ processed+ib ], 1, dCarray, 1, queue);
 
             if (layout == Layout::RowMajor) {
@@ -827,9 +816,7 @@ void gemm(
     }
 
     // set device
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     std::complex<float> **dAarray, **dBarray, **dCarray;
     size_t batch_limit = queue.get_batch_limit();
@@ -860,13 +847,13 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<std::complex<float>*>(
+            device_copy_vector<std::complex<float>*>(
                 ibatch, (std::complex<float>**) &Aarray[ processed+ib ], 1,
                 dAarray, 1, queue);
-            device_setvector<std::complex<float>*>(
+            device_copy_vector<std::complex<float>*>(
                 ibatch, (std::complex<float>**) &Barray[ processed+ib ], 1,
                 dBarray, 1, queue);
-            device_setvector<std::complex<float>*>(
+            device_copy_vector<std::complex<float>*>(
                 ibatch, (std::complex<float>**) &Carray[ processed+ib ], 1,
                 dCarray, 1, queue);
 
@@ -959,9 +946,7 @@ void gemm(
     }
 
     // set device
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     std::complex<double> **dAarray, **dBarray, **dCarray;
     size_t batch_limit = queue.get_batch_limit();
@@ -992,13 +977,13 @@ void gemm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy Aarray, Barray, and Carray to device
-            device_setvector<std::complex<double>*>(
+            device_copy_vector<std::complex<double>*>(
                 ibatch, (std::complex<double>**) &Aarray[ processed+ib ], 1,
                 dAarray, 1, queue);
-            device_setvector<std::complex<double>*>(
+            device_copy_vector<std::complex<double>*>(
                 ibatch, (std::complex<double>**) &Barray[ processed+ib ], 1,
                 dBarray, 1, queue);
-            device_setvector<std::complex<double>*>(
+            device_copy_vector<std::complex<double>*>(
                 ibatch, (std::complex<double>**) &Carray[ processed+ib ], 1,
                 dCarray, 1, queue);
 

--- a/src/device_batch_hemm.cc
+++ b/src/device_batch_hemm.cc
@@ -38,9 +38,7 @@ void blas::batch::hemm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -96,9 +94,7 @@ void blas::batch::hemm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -154,9 +150,7 @@ void blas::batch::hemm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -212,9 +206,7 @@ void blas::batch::hemm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_her2k.cc
+++ b/src/device_batch_her2k.cc
@@ -38,9 +38,7 @@ void blas::batch::her2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -96,9 +94,7 @@ void blas::batch::her2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -154,9 +150,7 @@ void blas::batch::her2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -212,9 +206,7 @@ void blas::batch::her2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_herk.cc
+++ b/src/device_batch_herk.cc
@@ -36,9 +36,7 @@ void blas::batch::herk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -89,9 +87,7 @@ void blas::batch::herk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -142,9 +138,7 @@ void blas::batch::herk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -195,9 +189,7 @@ void blas::batch::herk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_symm.cc
+++ b/src/device_batch_symm.cc
@@ -38,9 +38,7 @@ void blas::batch::symm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -96,9 +94,7 @@ void blas::batch::symm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -154,9 +150,7 @@ void blas::batch::symm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -212,9 +206,7 @@ void blas::batch::symm(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_syr2k.cc
+++ b/src/device_batch_syr2k.cc
@@ -38,9 +38,7 @@ void blas::batch::syr2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -96,9 +94,7 @@ void blas::batch::syr2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -154,9 +150,7 @@ void blas::batch::syr2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -212,9 +206,7 @@ void blas::batch::syr2k(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_syrk.cc
+++ b/src/device_batch_syrk.cc
@@ -36,9 +36,7 @@ void blas::batch::syrk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -89,9 +87,7 @@ void blas::batch::syrk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -142,9 +138,7 @@ void blas::batch::syrk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {
@@ -195,9 +189,7 @@ void blas::batch::syrk(
                         batch, info );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     queue.fork();
     for (size_t i = 0; i < batch; ++i) {

--- a/src/device_batch_trmm.cc
+++ b/src/device_batch_trmm.cc
@@ -43,9 +43,7 @@ void blas::batch::trmm(
         const bool fork = true;
     #endif
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     if (fork)
         queue.fork();
@@ -108,9 +106,7 @@ void blas::batch::trmm(
         const bool fork = true;
     #endif
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     if (fork)
         queue.fork();
@@ -173,9 +169,7 @@ void blas::batch::trmm(
         const bool fork = true;
     #endif
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     if (fork)
         queue.fork();
@@ -237,9 +231,7 @@ void blas::batch::trmm(
         const bool fork = true;
     #endif
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     if (fork)
         queue.fork();

--- a/src/device_batch_trsm.cc
+++ b/src/device_batch_trsm.cc
@@ -51,9 +51,8 @@ void blas::batch::trsm(
                           Barray.size() == batch &&
                           lddb.size()   == 1  );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
+
     if (fixed_size) {
         // call the vendor routine
         device_blas_int m_      = (device_blas_int) m[0];
@@ -83,8 +82,8 @@ void blas::batch::trsm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy pointer array(s) to device
-            device_setvector<float*>(ibatch, (float**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector<float*>(ibatch, (float**)&Barray[ib], 1, dBarray, 1, queue);
+            device_copy_vector<float*>(ibatch, (float**)&Aarray[ib], 1, dAarray, 1, queue);
+            device_copy_vector<float*>(ibatch, (float**)&Barray[ib], 1, dBarray, 1, queue);
 
             device::batch_strsm( queue,
                                 side_, uplo_, trans_, diag_,
@@ -158,9 +157,8 @@ void blas::batch::trsm(
                           Barray.size() == batch &&
                           lddb.size()   == 1  );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
+
     if (fixed_size) {
         // call the vendor routine
         device_blas_int m_      = (device_blas_int) m[0];
@@ -190,8 +188,8 @@ void blas::batch::trsm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy pointer array(s) to device
-            device_setvector<double*>(ibatch, (double**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector<double*>(ibatch, (double**)&Barray[ib], 1, dBarray, 1, queue);
+            device_copy_vector<double*>(ibatch, (double**)&Aarray[ib], 1, dAarray, 1, queue);
+            device_copy_vector<double*>(ibatch, (double**)&Barray[ib], 1, dBarray, 1, queue);
 
             device::batch_dtrsm( queue,
                                 side_, uplo_, trans_, diag_,
@@ -265,9 +263,8 @@ void blas::batch::trsm(
                           Barray.size() == batch &&
                           lddb.size()   == 1  );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
+
     if (fixed_size) {
         // call the vendor routine
         device_blas_int m_      = (device_blas_int) m[0];
@@ -297,8 +294,8 @@ void blas::batch::trsm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy pointer array(s) to device
-            device_setvector< std::complex<float>* >(ibatch, (std::complex<float>**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector< std::complex<float>* >(ibatch, (std::complex<float>**)&Barray[ib], 1, dBarray, 1, queue);
+            device_copy_vector< std::complex<float>* >(ibatch, (std::complex<float>**)&Aarray[ib], 1, dAarray, 1, queue);
+            device_copy_vector< std::complex<float>* >(ibatch, (std::complex<float>**)&Barray[ib], 1, dBarray, 1, queue);
 
             device::batch_ctrsm( queue,
                                 side_, uplo_, trans_, diag_,
@@ -372,9 +369,8 @@ void blas::batch::trsm(
                           Barray.size() == batch &&
                           lddb.size()   == 1  );
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
+
     if (fixed_size) {
         // call the vendor routine
         device_blas_int m_      = (device_blas_int) m[0];
@@ -404,8 +400,8 @@ void blas::batch::trsm(
             size_t ibatch = std::min( batch_limit, batch-ib );
 
             // copy pointer array(s) to device
-            device_setvector< std::complex<double>* >(ibatch, (std::complex<double>**)&Aarray[ib], 1, dAarray, 1, queue);
-            device_setvector< std::complex<double>* >(ibatch, (std::complex<double>**)&Barray[ib], 1, dBarray, 1, queue);
+            device_copy_vector< std::complex<double>* >(ibatch, (std::complex<double>**)&Aarray[ib], 1, dAarray, 1, queue);
+            device_copy_vector< std::complex<double>* >(ibatch, (std::complex<double>**)&Barray[ib], 1, dBarray, 1, queue);
 
             device::batch_ztrsm( queue,
                                 side_, uplo_, trans_, diag_,

--- a/src/device_copy.cc
+++ b/src/device_copy.cc
@@ -36,9 +36,7 @@ void blas::copy(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::scopy(
         queue,
@@ -70,9 +68,7 @@ void blas::copy(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::dcopy(
         queue,
@@ -104,9 +100,7 @@ void blas::copy(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::ccopy(
         queue,
@@ -138,9 +132,7 @@ void blas::copy(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::zcopy(
         queue,

--- a/src/device_gemm.cc
+++ b/src/device_gemm.cc
@@ -71,9 +71,7 @@ void blas::gemm(
     device_blas_int lddb_   = (device_blas_int) lddb;
     device_blas_int lddc_   = (device_blas_int) lddc;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (layout == Layout::RowMajor) {
         // swap transA <=> transB, m <=> n, B <=> A
         device::sgemm(
@@ -163,9 +161,7 @@ void blas::gemm(
     device_blas_int lddb_   = (device_blas_int) lddb;
     device_blas_int lddc_   = (device_blas_int) lddc;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (layout == Layout::RowMajor) {
         // swap transA <=> transB, m <=> n, B <=> A
         device::dgemm(
@@ -254,9 +250,7 @@ void blas::gemm(
     device_blas_int lddb_   = (device_blas_int) lddb;
     device_blas_int lddc_   = (device_blas_int) lddc;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (layout == Layout::RowMajor) {
         // swap transA <=> transB, m <=> n, B <=> A
         device::cgemm(
@@ -345,9 +339,7 @@ void blas::gemm(
     device_blas_int lddb_   = (device_blas_int) lddb;
     device_blas_int lddc_   = (device_blas_int) lddc;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     if (layout == Layout::RowMajor) {
         // swap transA <=> transB, m <=> n, B <=> A
         device::zgemm(

--- a/src/device_hemm.cc
+++ b/src/device_hemm.cc
@@ -108,9 +108,7 @@ void blas::hemm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::chemm(
             queue,
             side, uplo, m_, n_,
@@ -181,9 +179,7 @@ void blas::hemm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zhemm(
             queue,
             side, uplo, m_, n_,

--- a/src/device_her2k.cc
+++ b/src/device_her2k.cc
@@ -102,9 +102,7 @@ void blas::her2k(
         trans = (trans == Op::NoTrans ? Op::ConjTrans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::cher2k(
             queue,
             uplo, trans, n_, k_,
@@ -169,9 +167,7 @@ void blas::her2k(
         trans = (trans == Op::NoTrans ? Op::ConjTrans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zher2k(
             queue,
             uplo, trans, n_, k_,

--- a/src/device_herk.cc
+++ b/src/device_herk.cc
@@ -94,9 +94,7 @@ void blas::herk(
         trans = (trans == Op::NoTrans ? Op::ConjTrans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::cherk(
             queue,
             uplo, trans,
@@ -155,9 +153,7 @@ void blas::herk(
         trans = (trans == Op::NoTrans ? Op::ConjTrans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zherk(
             queue,
             uplo, trans,

--- a/src/device_nrm2.cc
+++ b/src/device_nrm2.cc
@@ -33,9 +33,7 @@ void blas::nrm2(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::snrm2( queue, n_, dx, incdx_, result );
 }
@@ -61,9 +59,7 @@ void blas::nrm2(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::dnrm2( queue, n_, dx, incdx_, result );
 }
@@ -89,9 +85,7 @@ void blas::nrm2(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::cnrm2( queue, n_, dx, incdx_, result );
 }
@@ -117,9 +111,7 @@ void blas::nrm2(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::znrm2( queue, n_, dx, incdx_, result );
 }

--- a/src/device_queue.cc
+++ b/src/device_queue.cc
@@ -226,7 +226,7 @@ Queue::Queue( blas::Device device, int64_t batch_size )
         work_resize<void*>( lwork );
 
     #elif defined(BLAS_HAVE_ONEMKL)
-        std::vector<cl::sycl::device> devices;
+        std::vector<sycl::device> devices;
         enumerate_devices( devices );
         device_ = device;
         if (devices.size() <= (size_t)device) {

--- a/src/device_scal.cc
+++ b/src/device_scal.cc
@@ -33,9 +33,7 @@ void blas::scal(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::sscal( queue, n_, alpha, dx, incdx_ );
 }
@@ -61,9 +59,7 @@ void blas::scal(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::dscal( queue, n_, alpha, dx, incdx_ );
 }
@@ -89,9 +85,7 @@ void blas::scal(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::cscal( queue, n_, alpha, dx, incdx_ );
 }
@@ -117,9 +111,7 @@ void blas::scal(
     device_blas_int n_     = (device_blas_int) n;
     device_blas_int incdx_ = (device_blas_int) incdx;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::zscal( queue, n_, alpha, dx, incdx_ );
 }

--- a/src/device_swap.cc
+++ b/src/device_swap.cc
@@ -36,9 +36,7 @@ void blas::swap(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::sswap(
         queue,
@@ -71,9 +69,7 @@ void blas::swap(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::dswap(
         queue,
@@ -106,9 +102,7 @@ void blas::swap(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::cswap(
         queue,
@@ -141,9 +135,7 @@ void blas::swap(
     device_blas_int incdx_  = (device_blas_int) incdx;
     device_blas_int incdy_  = (device_blas_int) incdy;
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
 
     device::zswap(
         queue,

--- a/src/device_symm.cc
+++ b/src/device_symm.cc
@@ -74,9 +74,7 @@ void blas::symm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ssymm(
             queue,
             side, uplo, m_, n_,
@@ -147,9 +145,7 @@ void blas::symm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::dsymm(
             queue,
             side, uplo, m_, n_,
@@ -220,9 +216,7 @@ void blas::symm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::csymm(
             queue,
             side, uplo, m_, n_,
@@ -293,9 +287,7 @@ void blas::symm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zsymm(
             queue,
             side, uplo, m_, n_,

--- a/src/device_syr2k.cc
+++ b/src/device_syr2k.cc
@@ -69,9 +69,7 @@ void blas::syr2k(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ssyr2k(
             queue,
             uplo, trans,
@@ -138,9 +136,7 @@ void blas::syr2k(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::dsyr2k(
             queue,
             uplo, trans,
@@ -206,9 +202,7 @@ void blas::syr2k(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::csyr2k(
             queue,
             uplo, trans,
@@ -274,9 +268,7 @@ void blas::syr2k(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zsyr2k(
             queue,
             uplo, trans,

--- a/src/device_syrk.cc
+++ b/src/device_syrk.cc
@@ -63,9 +63,7 @@ void blas::syrk(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ssyrk(
             queue,
             uplo, trans,
@@ -125,9 +123,7 @@ void blas::syrk(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::dsyrk(
             queue,
             uplo, trans,
@@ -186,9 +182,7 @@ void blas::syrk(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::csyrk(
             queue,
             uplo, trans,
@@ -247,9 +241,7 @@ void blas::syrk(
         trans = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::zsyrk(
             queue,
             uplo, trans,

--- a/src/device_trmm.cc
+++ b/src/device_trmm.cc
@@ -72,9 +72,7 @@ void blas::trmm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::strmm(
             queue,
             side, uplo, trans, diag,
@@ -143,9 +141,7 @@ void blas::trmm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::dtrmm(
             queue,
             side, uplo, trans, diag,
@@ -214,9 +210,7 @@ void blas::trmm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ctrmm(
             queue,
             side, uplo, trans, diag,
@@ -285,9 +279,7 @@ void blas::trmm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ztrmm(
             queue,
             side, uplo, trans, diag,

--- a/src/device_trsm.cc
+++ b/src/device_trsm.cc
@@ -72,9 +72,7 @@ void blas::trsm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::strsm(
             queue,
             side, uplo, trans, diag,
@@ -143,9 +141,7 @@ void blas::trsm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::dtrsm(
             queue,
             side, uplo, trans, diag,
@@ -214,9 +210,7 @@ void blas::trsm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ctrsm(
             queue,
             side, uplo, trans, diag,
@@ -285,9 +279,7 @@ void blas::trsm(
         std::swap( m_, n_ );
     }
 
-    #ifndef BLAS_HAVE_ONEMKL
-    blas::set_device( queue.device() );
-    #endif
+    blas::internal_set_device( queue.device() );
     device::ztrsm(
             queue,
             side, uplo, trans, diag,

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -32,6 +32,27 @@ void set_device( blas::Device device )
 }
 
 // -----------------------------------------------------------------------------
+/// Set the current GPU device as needed by the accelerator/gpu.
+/// (CUDA, ROCm only; no-op for SYCL.)
+void internal_set_device( blas::Device device )
+{
+    #ifdef BLAS_HAVE_CUBLAS
+        blas_dev_call(
+            cudaSetDevice((device_blas_int)device) );
+
+    #elif defined(BLAS_HAVE_ROCBLAS)
+        blas_dev_call(
+            hipSetDevice((device_blas_int)device) );
+
+    #elif defined(BLAS_HAVE_ONEMKL)
+        // skip, no need to throw error since this is an internal function
+
+    #else
+        throw blas::Error( "unknown accelerator/gpu", __func__ );
+    #endif
+}
+
+// -----------------------------------------------------------------------------
 /// @deprecated
 /// Get current GPU device.
 /// (CUDA, ROCm only; doesn't work with SYCL.)
@@ -150,12 +171,12 @@ void device_free( void* ptr )
 void device_free( void* ptr, blas::Queue &queue )
 {
     #ifdef BLAS_HAVE_CUBLAS
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             cudaFree( ptr ) );
 
     #elif defined(BLAS_HAVE_ROCBLAS)
-        blas::set_device( queue.device() );
+        blas::internal_set_device( queue.device() );
         blas_dev_call(
             hipFree( ptr ) );
 

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -113,7 +113,7 @@ device_blas_int get_device_count()
 // -----------------------------------------------------------------------------
 /// @return vector of SYCL GPU devices.
 #ifdef BLAS_HAVE_ONEMKL
-void enumerate_devices(std::vector<cl::sycl::device> &devices)
+void enumerate_devices(std::vector<sycl::device> &devices)
 {
     device_blas_int dev_count = get_device_count();
 

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -69,8 +69,8 @@ void test_axpy_device_work( Params& params, bool run )
     cblas_copy( n, y, incy, yref, incy );
     cblas_copy( n, y, incy,   y0, incy );
 
-    blas::device_setvector(n, x, std::abs(incx), dx, std::abs(incx), queue);
-    blas::device_setvector(n, y, std::abs(incy), dy, std::abs(incy), queue);
+    blas::device_copy_vector(n, x, std::abs(incx), dx, std::abs(incx), queue);
+    blas::device_copy_vector(n, y, std::abs(incy), dy, std::abs(incy), queue);
     queue.sync();
 
     // test error exits
@@ -102,7 +102,7 @@ void test_axpy_device_work( Params& params, bool run )
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;
 
-    blas::device_getvector(n, dy, std::abs(incy), y, std::abs(incy), queue);
+    blas::device_copy_vector(n, dy, std::abs(incy), y, std::abs(incy), queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_batch_gemm_device.cc
+++ b/test/test_batch_gemm_device.cc
@@ -120,9 +120,9 @@ void test_device_batch_gemm_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", Cm, batch * Cn, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(Am, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
-    blas::device_setmatrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(Am, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -151,7 +151,7 @@ void test_device_batch_gemm_work( Params& params, bool run )
     double gflop = batch * blas::Gflop< scalar_t >::gemm( m_, n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
     queue.sync();
 
     if (params.ref() == 'y' || params.check() == 'y') {

--- a/test/test_batch_hemm_device.cc
+++ b/test/test_batch_hemm_device.cc
@@ -109,9 +109,9 @@ void test_batch_hemm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", Cm, batch * Cn, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(An, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Cm, batch * Cn, B, ldb_, dB, ldb_, queue);
-    blas::device_setmatrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(An, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -141,7 +141,7 @@ void test_batch_hemm_device_work( Params& params, bool run )
     params.time()   = time;
     params.gflops() = gflop / time;
 
-    blas::device_getmatrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
     queue.sync();
     if (params.ref() == 'y' || params.check() == 'y') {
         // run reference

--- a/test/test_batch_her2k_device.cc
+++ b/test/test_batch_her2k_device.cc
@@ -108,9 +108,9 @@ void test_batch_her2k_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", n_, batch * n_, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(Am, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Am, batch * An, B, ldb_, dB, ldb_, queue);
-    blas::device_setmatrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(Am, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Am, batch * An, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -139,7 +139,7 @@ void test_batch_her2k_device_work( Params& params, bool run )
     double gflop = batch * blas::Gflop< scalar_t >::her2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
     queue.sync();
 
     if (params.ref() == 'y' || params.check() == 'y') {

--- a/test/test_batch_herk_device.cc
+++ b/test/test_batch_herk_device.cc
@@ -98,8 +98,8 @@ void test_batch_herk_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", n_, batch * n_, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(Am, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(Am, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -126,7 +126,7 @@ void test_batch_herk_device_work( Params& params, bool run )
     double gflop = batch * blas::Gflop< scalar_t >::herk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
     queue.sync();
 
     if (params.ref() == 'y' || params.check() == 'y') {

--- a/test/test_batch_symm_device.cc
+++ b/test/test_batch_symm_device.cc
@@ -108,9 +108,9 @@ void test_batch_symm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", Cm, batch * Cn, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(An, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Cm, batch * Cn, B, ldb_, dB, ldb_, queue);
-    blas::device_setmatrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(An, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -139,7 +139,7 @@ void test_batch_symm_device_work( Params& params, bool run )
     params.time()   = time;
     params.gflops() = gflop / time;
 
-    blas::device_getmatrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(Cm, batch * Cn, dC, ldc_, C, ldc_, queue);
     queue.sync();
     if (params.ref() == 'y' || params.check() == 'y') {
         // run reference

--- a/test/test_batch_syr2k_device.cc
+++ b/test/test_batch_syr2k_device.cc
@@ -108,9 +108,9 @@ void test_batch_syr2k_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", n_, batch * n_, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(Am, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Am, batch * An, B, ldb_, dB, ldb_, queue);
-    blas::device_setmatrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(Am, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Am, batch * An, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -139,7 +139,7 @@ void test_batch_syr2k_device_work( Params& params, bool run )
     double gflop = batch * blas::Gflop< scalar_t >::syr2k( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
     queue.sync();
 
     if (params.ref() == 'y' || params.check() == 'y') {

--- a/test/test_batch_syrk_device.cc
+++ b/test/test_batch_syrk_device.cc
@@ -98,8 +98,8 @@ void test_batch_syrk_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_C, C );
     lapack_lacpy( "g", n_, batch * n_, C, ldc_, Cref, ldc_ );
 
-    blas::device_setmatrix(Am, batch * An, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
+    blas::device_copy_matrix(Am, batch * An, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(n_, batch * n_, C, ldc_, dC, ldc_, queue);
     queue.sync();
 
     // norms for error check
@@ -126,7 +126,7 @@ void test_batch_syrk_device_work( Params& params, bool run )
     double gflop = batch * blas::Gflop< scalar_t >::syrk( n_, k_ );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
+    blas::device_copy_matrix(n_, batch * n_, dC, ldc_, C, ldc_, queue);
     queue.sync();
 
     if (params.ref() == 'y' || params.check() == 'y') {

--- a/test/test_batch_trmm_device.cc
+++ b/test/test_batch_trmm_device.cc
@@ -102,8 +102,8 @@ void test_batch_trmm_work_device( Params& params, bool run )
     lapack_larnv( idist, iseed, batch * size_B, B );  // TODO
     lapack_lacpy( "g", Bm, batch * Bn, B, ldb_, Bref, ldb_ );
 
-    blas::device_setmatrix(Am, batch * Am, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(Am, batch * Am, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
     queue.sync();
 
     // norms for error check
@@ -131,7 +131,7 @@ void test_batch_trmm_work_device( Params& params, bool run )
     params.time()   = time;
     params.gflops() = gflop / time;
 
-    blas::device_getmatrix(Bm, batch * Bn, dB, ldb_, B, ldb_, queue);
+    blas::device_copy_matrix(Bm, batch * Bn, dB, ldb_, B, ldb_, queue);
     queue.sync();
 
     if (params.check() == 'y') {

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -145,8 +145,8 @@ void test_device_batch_trsm_work( Params& params, bool run )
         }
     }
 
-    blas::device_setmatrix(Am, batch * Am, A, lda_, dA, lda_, queue);
-    blas::device_setmatrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
+    blas::device_copy_matrix(Am, batch * Am, A, lda_, dA, lda_, queue);
+    blas::device_copy_matrix(Bm, batch * Bn, B, ldb_, dB, ldb_, queue);
     queue.sync();
 
     // norms for error check
@@ -173,7 +173,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
     params.time()   = time;
     params.gflops() = gflop / time;
 
-    blas::device_getmatrix(Bm, batch * Bn, dB, ldb_, B, ldb_, queue);
+    blas::device_copy_matrix(Bm, batch * Bn, dB, ldb_, B, ldb_, queue);
     queue.sync();
 
     if (params.check() == 'y') {

--- a/test/test_copy_device.cc
+++ b/test/test_copy_device.cc
@@ -69,8 +69,8 @@ void test_copy_device_work( Params& params, bool run )
 
     // todo: should we have different incdx and incdy
     // todo: setvector assumes one type TX=TY
-    blas::device_setvector(n, x, std::abs(incx), dx, std::abs(incx), queue);
-    blas::device_setvector(n, y, std::abs(incy), dy, std::abs(incy), queue);
+    blas::device_copy_vector(n, x, std::abs(incx), dx, std::abs(incx), queue);
+    blas::device_copy_vector(n, y, std::abs(incy), dy, std::abs(incy), queue);
     queue.sync();
 
     // test error exits
@@ -104,8 +104,8 @@ void test_copy_device_work( Params& params, bool run )
     params.gbytes() = gbyte / time;
 
     // todo: should we have different incdx and incdy
-    blas::device_getvector(n, dx, std::abs(incx), x, std::abs(incx), queue);
-    blas::device_getvector(n, dy, std::abs(incy), y, std::abs(incy), queue);
+    blas::device_copy_vector(n, dx, std::abs(incx), x, std::abs(incx), queue);
+    blas::device_copy_vector(n, dy, std::abs(incy), y, std::abs(incy), queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_gemm_device.cc
+++ b/test/test_gemm_device.cc
@@ -88,9 +88,9 @@ void test_gemm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", Cm, Cn, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(Am, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Bm, Bn, B, ldb, dB, ldb, queue);
-    blas::device_setmatrix(Cm, Cn, C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(Am, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Bm, Bn, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(Cm, Cn, C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -155,7 +155,7 @@ void test_gemm_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::gemm( m, n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(Cm, Cn, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_hemm_device.cc
+++ b/test/test_hemm_device.cc
@@ -82,9 +82,9 @@ void test_hemm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", Cm, Cn, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(An, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Cm, Cn, B, ldb, dB, ldb, queue);
-    blas::device_setmatrix(Cm, Cn, C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(An, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Cm, Cn, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(Cm, Cn, C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -140,7 +140,7 @@ void test_hemm_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::hemm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(Cm, Cn, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_her2k_device.cc
+++ b/test/test_her2k_device.cc
@@ -81,9 +81,9 @@ void test_her2k_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", n, n, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(Am, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Am, An, B, ldb, dB, ldb, queue);
-    blas::device_setmatrix(n, n, C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(Am, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Am, An, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(n, n, C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -148,7 +148,7 @@ void test_her2k_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::her2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(n, n, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_herk_device.cc
+++ b/test/test_herk_device.cc
@@ -73,8 +73,8 @@ void test_herk_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", n, n, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(Am, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(n,  n,  C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(Am, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(n,  n,  C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -125,7 +125,7 @@ void test_herk_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::herk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(n, n, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_memcpy.cc
+++ b/test/test_memcpy.cc
@@ -114,13 +114,13 @@ void test_memcpy_work( Params& params, bool run )
     assert_throw( blas::device_copy_vector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
     assert_throw( blas::device_copy_vector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
 
-    assert_throw( blas::device_setvector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
-    assert_throw( blas::device_setvector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
-    assert_throw( blas::device_setvector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
 
-    assert_throw( blas::device_getvector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
-    assert_throw( blas::device_getvector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
-    assert_throw( blas::device_getvector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector( -1, b_dev, 1, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 0, c_dev, 1, queue ), blas::Error );
+    assert_throw( blas::device_copy_vector(  n, b_dev, 1, c_dev, 0, queue ), blas::Error );
 
     if (verbose >= 1) {
         printf( "\n"
@@ -147,7 +147,7 @@ void test_memcpy_work( Params& params, bool run )
         blas::device_copy_vector( n, a_host, inc_ac, b_dev, inc_bd, queue );
     }
     else if (method == Method::set_vector) {
-        blas::device_setvector( n, a_host, inc_ac, b_dev, inc_bd, queue );
+        blas::device_copy_vector( n, a_host, inc_ac, b_dev, inc_bd, queue );
     }
     time = sync_get_wtime( queue ) - time;
 
@@ -179,7 +179,7 @@ void test_memcpy_work( Params& params, bool run )
         blas::device_copy_vector( n, c_dev, inc_ac, d_host, inc_bd, queue );
     }
     else if (method == Method::set_vector) {
-        blas::device_getvector( n, c_dev, inc_ac, d_host, inc_bd, queue );
+        blas::device_copy_vector( n, c_dev, inc_ac, d_host, inc_bd, queue );
     }
     time3 = sync_get_wtime( queue ) - time3;
 

--- a/test/test_memcpy_2d.cc
+++ b/test/test_memcpy_2d.cc
@@ -107,15 +107,15 @@ void test_memcpy_2d_work( Params& params, bool run )
     assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
     assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
 
-    assert_throw( blas::device_setmatrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_setmatrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_setmatrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_setmatrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
 
-    assert_throw( blas::device_getmatrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_getmatrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_getmatrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
-    assert_throw( blas::device_getmatrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix( -1,  n, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m, -1, b_dev, m,   c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m-1, c_dev, m,   queue ), blas::Error );
+    assert_throw( blas::device_copy_matrix(  m,  n, b_dev, m,   c_dev, m-1, queue ), blas::Error );
 
     if (verbose >= 1) {
         printf( "\n"
@@ -139,7 +139,7 @@ void test_memcpy_2d_work( Params& params, bool run )
         blas::device_copy_matrix( m, n, a_host, ld, b_dev, ld, queue );
     }
     else if (method == Method::set_matrix) {
-        blas::device_setmatrix( m, n, a_host, ld, b_dev, ld, queue );
+        blas::device_copy_matrix( m, n, a_host, ld, b_dev, ld, queue );
     }
     time = sync_get_wtime( queue ) - time;
 
@@ -165,7 +165,7 @@ void test_memcpy_2d_work( Params& params, bool run )
         blas::device_copy_matrix( m, n, c_dev, ld, d_host, ld, queue );
     }
     else if (method == Method::set_matrix) {
-        blas::device_getmatrix( m, n, c_dev, ld, d_host, ld, queue );
+        blas::device_copy_matrix( m, n, c_dev, ld, d_host, ld, queue );
     }
     time3 = sync_get_wtime( queue ) - time3;
 

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -76,7 +76,7 @@ void test_nrm2_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_x, x );
     cblas_copy( n, x, incx, xref, incx );
 
-    blas::device_setvector(n, x, std::abs(incx), dx, std::abs(incx), queue);
+    blas::device_copy_vector(n, x, std::abs(incx), dx, std::abs(incx), queue);
     queue.sync();
 
     if (verbose >= 1) {
@@ -105,7 +105,7 @@ void test_nrm2_device_work( Params& params, bool run )
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;
 
-    blas::device_getvector(n, dx, std::abs(incx), x, std::abs(incx), queue);
+    blas::device_copy_vector(n, dx, std::abs(incx), x, std::abs(incx), queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -61,7 +61,7 @@ void test_scal_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_x, x );
     cblas_copy( n, x, incx, xref, incx );
 
-    blas::device_setvector(n, x, std::abs(incx), dx, std::abs(incx), queue);
+    blas::device_copy_vector(n, x, std::abs(incx), dx, std::abs(incx), queue);
     queue.sync();
 
     // test error exits
@@ -93,7 +93,7 @@ void test_scal_device_work( Params& params, bool run )
     params.gflops() = gflop / time;
     params.gbytes() = gbyte / time;
 
-    blas::device_getvector(n, dx, std::abs(incx), x, std::abs(incx), queue);
+    blas::device_copy_vector(n, dx, std::abs(incx), x, std::abs(incx), queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_swap_device.cc
+++ b/test/test_swap_device.cc
@@ -68,8 +68,8 @@ void test_swap_device_work( Params& params, bool run )
     cblas_copy( n, y, incy, yref, incy );
 
     // todo: should we have different incdx and incdy
-    blas::device_setvector(n, x, std::abs(incx), dx, std::abs(incx), queue);
-    blas::device_setvector(n, y, std::abs(incy), dy, std::abs(incy), queue);
+    blas::device_copy_vector(n, x, std::abs(incx), dx, std::abs(incx), queue);
+    blas::device_copy_vector(n, y, std::abs(incy), dy, std::abs(incy), queue);
     queue.sync();
 
     // test error exits
@@ -103,8 +103,8 @@ void test_swap_device_work( Params& params, bool run )
     params.gbytes() = gbyte / time;
 
     // todo: should we have different incdx and incdy
-    blas::device_getvector(n, dx, std::abs(incx), x, std::abs(incx), queue);
-    blas::device_getvector(n, dy, std::abs(incy), y, std::abs(incy), queue);
+    blas::device_copy_vector(n, dx, std::abs(incx), x, std::abs(incx), queue);
+    blas::device_copy_vector(n, dy, std::abs(incy), y, std::abs(incy), queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_symm_device.cc
+++ b/test/test_symm_device.cc
@@ -82,9 +82,9 @@ void test_symm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", Cm, Cn, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(An, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Cm, Cn, B, ldb, dB, ldb, queue);
-    blas::device_setmatrix(Cm, Cn, C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(An, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Cm, Cn, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(Cm, Cn, C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -140,7 +140,7 @@ void test_symm_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::symm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Cm, Cn, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(Cm, Cn, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_syr2k_device.cc
+++ b/test/test_syr2k_device.cc
@@ -81,9 +81,9 @@ void test_syr2k_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", n, n, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(Am, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Am, An, B, ldb, dB, ldb, queue);
-    blas::device_setmatrix(n, n, C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(Am, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Am, An, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(n, n, C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -148,7 +148,7 @@ void test_syr2k_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::syr2k( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(n, n, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_syrk_device.cc
+++ b/test/test_syrk_device.cc
@@ -75,8 +75,8 @@ void test_syrk_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_C, C );
     lapack_lacpy( "g", n, n, C, ldc, Cref, ldc );
 
-    blas::device_setmatrix(Am, An, A, lda, dA, lda, queue);
-    blas::device_setmatrix(n,  n,  C, ldc, dC, ldc, queue);
+    blas::device_copy_matrix(Am, An, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(n,  n,  C, ldc, dC, ldc, queue);
     queue.sync();
 
     // norms for error check
@@ -129,7 +129,7 @@ void test_syrk_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::syrk( n, k );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(n, n, dC, ldc, C, ldc, queue);
+    blas::device_copy_matrix(n, n, dC, ldc, C, ldc, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_trmm_device.cc
+++ b/test/test_trmm_device.cc
@@ -78,8 +78,8 @@ void test_trmm_device_work( Params& params, bool run )
     lapack_larnv( idist, iseed, size_B, B );  // TODO
     lapack_lacpy( "g", Bm, Bn, B, ldb, Bref, ldb );
 
-    blas::device_setmatrix(Am, Am, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Bm, Bn, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(Am, Am, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Bm, Bn, B, ldb, dB, ldb, queue);
     queue.sync();
 
     // norms for error check
@@ -125,7 +125,7 @@ void test_trmm_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::trmm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Bm, Bn, dB, ldb, B, ldb, queue);
+    blas::device_copy_matrix(Bm, Bn, dB, ldb, B, ldb, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -115,8 +115,8 @@ void test_trsm_device_work( Params& params, bool run )
         }
     }
 
-    blas::device_setmatrix(Am, Am, A, lda, dA, lda, queue);
-    blas::device_setmatrix(Bm, Bn, B, ldb, dB, ldb, queue);
+    blas::device_copy_matrix(Am, Am, A, lda, dA, lda, queue);
+    blas::device_copy_matrix(Bm, Bn, B, ldb, dB, ldb, queue);
     queue.sync();
 
     // test error exits
@@ -156,7 +156,7 @@ void test_trsm_device_work( Params& params, bool run )
     double gflop = blas::Gflop< scalar_t >::trsm( side, m, n );
     params.time()   = time;
     params.gflops() = gflop / time;
-    blas::device_getmatrix(Bm, Bn, dB, ldb, B, ldb, queue);
+    blas::device_copy_matrix(Bm, Bn, dB, ldb, B, ldb, queue);
     queue.sync();
 
     if (verbose >= 2) {

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -354,27 +354,6 @@ void test_device()
     int cnt = blas::get_device_count();
     printf( "    get_device_count %d\n", cnt );
     require( cnt >= 0 );
-
-    #ifndef BLAS_HAVE_ONEMKL
-    int verbose = 3; // used in assert_throw
-    blas::Device dev;
-    if (cnt > 0) {
-        blas::get_device( &dev );
-        printf( "    get_device %d\n", dev );
-        require( dev >= 0 );
-    }
-    else {
-        assert_throw( blas::get_device( &dev ), blas::Error );
-    }
-
-    if (cnt > 0) {
-        blas::set_device( cnt-1 );
-        printf( "    set_device %d\n", cnt-1 );
-        blas::get_device( &dev );
-        printf( "    get_device %d\n", dev );
-        require( dev == cnt-1 );
-    }
-    #endif
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Deprecate some older blaspp apis. 
Update to use the newer SYCL APIs (without CL namespace).
