### PR TITLE
Refactor batch

### DIFF
--- a/include/blas/device_blas.hh
+++ b/include/blas/device_blas.hh
@@ -7,225 +7,217 @@
 
 #include <vector>
 
-/** device blas++ **/
-
 namespace blas {
 
-// =============================================================================
+//==============================================================================
 // Level 1 BLAS
+// Alphabetical order
 
-// -----------------------------------------------------------------------------
-// axpy
+//------------------------------------------------------------------------------
 void axpy(
     int64_t n,
     float alpha,
-    float const* dx, int64_t incdx,
-    float *dy, int64_t incdy,
-    blas::Queue& queue);
+    float const* x, int64_t incx,
+    float*       y, int64_t incy,
+    blas::Queue& queue );
 
 void axpy(
     int64_t n,
     double alpha,
-    double const* dx, int64_t incdx,
-    double *dy, int64_t incdy,
-    blas::Queue& queue);
+    double const* x, int64_t incx,
+    double*       y, int64_t incy,
+    blas::Queue& queue );
 
 void axpy(
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const* dx, int64_t incdx,
-    std::complex<float> *dy, int64_t incdy,
-    blas::Queue& queue);
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float>*       y, int64_t incy,
+    blas::Queue& queue );
 
 void axpy(
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const* dx, int64_t incdx,
-    std::complex<double> *dy, int64_t incdy,
-    blas::Queue& queue);
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double>*       y, int64_t incy,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// dot
+//------------------------------------------------------------------------------
+void copy(
+    int64_t n,
+    float const* x, int64_t incx,
+    float*       y, int64_t incy,
+    blas::Queue& queue );
+
+void copy(
+    int64_t n,
+    double const* x, int64_t incx,
+    double*       y, int64_t incy,
+    blas::Queue& queue );
+
+void copy(
+    int64_t n,
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float>*       y, int64_t incy,
+    blas::Queue& queue );
+
+void copy(
+    int64_t n,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double>*       y, int64_t incy,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void dot(
     int64_t n,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float *result,
-    blas::Queue& queue);
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float* result,
+    blas::Queue& queue );
 
 void dot(
     int64_t n,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double *result,
-    blas::Queue& queue);
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double* result,
+    blas::Queue& queue );
 
 void dot(
     int64_t n,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float> *result,
-    blas::Queue& queue);
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>* result,
+    blas::Queue& queue );
 
 void dot(
     int64_t n,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double> *result,
-    blas::Queue& queue);
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>* result,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// dotu
+//------------------------------------------------------------------------------
 void dotu(
     int64_t n,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float *result,
-    blas::Queue& queue);
-
-void dotu(
-    int64_t n,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double *result,
-    blas::Queue& queue);
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float* result,
+    blas::Queue& queue );
 
 void dotu(
     int64_t n,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float> *result,
-    blas::Queue& queue);
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double* result,
+    blas::Queue& queue );
 
 void dotu(
     int64_t n,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double> *result,
-    blas::Queue& queue);
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>* result,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// nrm2
+void dotu(
+    int64_t n,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>* result,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void nrm2(
     int64_t n,
-    float const* dx, int64_t incdx,
-    float *result,
-    blas::Queue& queue);
-
-void nrm2(
-    int64_t n,
-    double const* dx, int64_t incdx,
-    double *result,
-    blas::Queue& queue);
-
-void nrm2(
-    int64_t n,
-    std::complex<float> const* dx, int64_t incdx,
-    float *result,
-    blas::Queue& queue);
+    float const* x, int64_t incx,
+    float* result,
+    blas::Queue& queue );
 
 void nrm2(
     int64_t n,
-    std::complex<double> const* dx, int64_t incdx,
-    double *result,
-    blas::Queue& queue);
+    double const* x, int64_t incx,
+    double* result,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// scal
+void nrm2(
+    int64_t n,
+    std::complex<float> const* x, int64_t incx,
+    float* result,
+    blas::Queue& queue );
+
+void nrm2(
+    int64_t n,
+    std::complex<double> const* x, int64_t incx,
+    double* result,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void scal(
     int64_t n,
     float alpha,
-    float *dx, int64_t incdx,
-    blas::Queue& queue);
+    float* x, int64_t incx,
+    blas::Queue& queue );
 
 void scal(
     int64_t n,
     double alpha,
-    double *dx, int64_t incdx,
-    blas::Queue& queue);
+    double* x, int64_t incx,
+    blas::Queue& queue );
 
 void scal(
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> *dx, int64_t incdx,
-    blas::Queue& queue);
+    std::complex<float>* x, int64_t incx,
+    blas::Queue& queue );
 
 void scal(
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> *dx, int64_t incdx,
-    blas::Queue& queue);
+    std::complex<double>* x, int64_t incx,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// swap
+//------------------------------------------------------------------------------
 void swap(
     int64_t n,
-    float *dx, int64_t incdx,
-    float *dy, int64_t incdy,
-    blas::Queue &queue );
-
-void swap(
-    int64_t n,
-    double *dx, int64_t incdx,
-    double *dy, int64_t incdy,
-    blas::Queue &queue );
+    float* x, int64_t incx,
+    float* y, int64_t incy,
+    blas::Queue& queue );
 
 void swap(
     int64_t n,
-    std::complex<float> *dx, int64_t incdx,
-    std::complex<float> *dy, int64_t incdy,
-    blas::Queue &queue );
+    double* x, int64_t incx,
+    double* y, int64_t incy,
+    blas::Queue& queue );
 
 void swap(
     int64_t n,
-    std::complex<double> *dx, int64_t incdx,
-    std::complex<double> *dy, int64_t incdy,
-    blas::Queue &queue );
+    std::complex<float>* x, int64_t incx,
+    std::complex<float>* y, int64_t incy,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// copy
-void copy(
+void swap(
     int64_t n,
-    float const *dx, int64_t incdx,
-    float *dy, int64_t incdy,
-    blas::Queue &queue );
+    std::complex<double>* x, int64_t incx,
+    std::complex<double>* y, int64_t incy,
+    blas::Queue& queue );
 
-void copy(
-    int64_t n,
-    double const *dx, int64_t incdx,
-    double *dy, int64_t incdy,
-    blas::Queue &queue );
-
-void copy(
-    int64_t n,
-    std::complex<float> const *dx, int64_t incdx,
-    std::complex<float> *dy, int64_t incdy,
-    blas::Queue &queue );
-
-void copy(
-    int64_t n,
-    std::complex<double> const *dx, int64_t incdx,
-    std::complex<double> *dy, int64_t incdy,
-    blas::Queue &queue );
-
-// =============================================================================
+//==============================================================================
 // Level 2 BLAS
 
-// =============================================================================
+//==============================================================================
 // Level 3 BLAS
-// -----------------------------------------------------------------------------
-// gemm
+
+//------------------------------------------------------------------------------
 void gemm(
     blas::Layout layout,
     blas::Op transA,
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     float alpha,
-    float const *dA, int64_t ldda,
-    float const *dB, int64_t lddb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void gemm(
     blas::Layout layout,
@@ -233,11 +225,11 @@ void gemm(
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     double alpha,
-    double const *dA, int64_t ldda,
-    double const *dB, int64_t lddb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void gemm(
     blas::Layout layout,
@@ -245,11 +237,11 @@ void gemm(
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> const *dB, int64_t lddb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void gemm(
     blas::Layout layout,
@@ -257,133 +249,24 @@ void gemm(
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> const *dB, int64_t lddb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// trsm
-void trsm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    float alpha,
-    float const *dA, int64_t ldda,
-    float       *dB, int64_t lddb,
-    blas::Queue &queue );
-
-void trsm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    double alpha,
-    double const *dA, int64_t ldda,
-    double       *dB, int64_t lddb,
-    blas::Queue  &queue );
-
-void trsm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float>       *dB, int64_t lddb,
-    blas::Queue  &queue );
-
-void trsm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double>       *dB, int64_t lddb,
-    blas::Queue  &queue );
-
-// -----------------------------------------------------------------------------
-// trmm
-void trmm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    float alpha,
-    float const *dA, int64_t ldda,
-    float       *dB, int64_t lddb,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    double alpha,
-    double const *dA, int64_t ldda,
-    double       *dB, int64_t lddb,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float>       *dB, int64_t lddb,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    blas::Op trans,
-    blas::Diag diag,
-    int64_t m,
-    int64_t n,
-    std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double>       *dB, int64_t lddb,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// hemm
+//------------------------------------------------------------------------------
 void hemm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     float alpha,
-    float const *dA, int64_t ldda,
-    float const *dB, int64_t lddb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void hemm(
     blas::Layout layout,
@@ -391,11 +274,11 @@ void hemm(
     blas::Uplo uplo,
     int64_t m, int64_t n,
     double alpha,
-    double const *dA, int64_t ldda,
-    double const *dB, int64_t lddb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void hemm(
     blas::Layout layout,
@@ -403,11 +286,11 @@ void hemm(
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> const *dB, int64_t lddb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void hemm(
     blas::Layout layout,
@@ -415,167 +298,24 @@ void hemm(
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> const *dB, int64_t lddb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// symm
-void symm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    int64_t m, int64_t n,
-    float alpha,
-    float const *dA, int64_t ldda,
-    float const *dB, int64_t lddb,
-    float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    int64_t m, int64_t n,
-    double alpha,
-    double const *dA, int64_t ldda,
-    double const *dB, int64_t lddb,
-    double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> const *dB, int64_t lddb,
-    std::complex<float> beta,
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout layout,
-    blas::Side side,
-    blas::Uplo uplo,
-    int64_t m, int64_t n,
-    std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> const *dB, int64_t lddb,
-    std::complex<double> beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// herk
-void herk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    float alpha,
-    float const *dA, int64_t ldda,
-    float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    double alpha,
-    double const *dA, int64_t ldda,
-    double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    float alpha,  // note: real
-    std::complex<float> const *dA, int64_t ldda,
-    float beta,   // note: real
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    double alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    double beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// syrk
-void syrk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    float alpha,
-    float const *dA, int64_t ldda,
-    float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    double alpha,
-    double const *dA, int64_t ldda,
-    double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> beta,
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    blas::Op trans,
-    int64_t n, int64_t k,
-    std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// her2k
+//------------------------------------------------------------------------------
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *dA, int64_t ldda,
-    float const *dB, int64_t lddb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void her2k(
     blas::Layout layout,
@@ -583,11 +323,11 @@ void her2k(
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *dA, int64_t ldda,
-    double const *dB, int64_t lddb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void her2k(
     blas::Layout layout,
@@ -595,11 +335,11 @@ void her2k(
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<float> alpha,  // note: complex
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> const *dB, int64_t lddb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     float beta,   // note: real
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void her2k(
     blas::Layout layout,
@@ -607,25 +347,118 @@ void her2k(
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<double> alpha,  // note: complex
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> const *dB, int64_t lddb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     double beta,  // note: real
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// syr2k
+//------------------------------------------------------------------------------
+void herk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    float alpha,
+    float const* A, int64_t lda,
+    float beta,
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    double alpha,
+    double const* A, int64_t lda,
+    double beta,
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    float alpha,  // note: real
+    std::complex<float> const* A, int64_t lda,
+    float beta,   // note: real
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    double alpha,
+    std::complex<double> const* A, int64_t lda,
+    double beta,
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void symm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    int64_t m, int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
+    float beta,
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    int64_t m, int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
+    double beta,
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
+    std::complex<float> beta,
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    int64_t m, int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
+    std::complex<double> beta,
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *dA, int64_t ldda,
-    float const *dB, int64_t lddb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *dC, int64_t lddc,
-    blas::Queue &queue );
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void syr2k(
     blas::Layout layout,
@@ -633,11 +466,11 @@ void syr2k(
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *dA, int64_t ldda,
-    double const *dB, int64_t lddb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *dC, int64_t lddc,
-    blas::Queue &queue );
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void syr2k(
     blas::Layout layout,
@@ -645,11 +478,11 @@ void syr2k(
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<float> alpha,
-    std::complex<float> const *dA, int64_t ldda,
-    std::complex<float> const *dB, int64_t lddb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
 
 void syr2k(
     blas::Layout layout,
@@ -657,599 +490,796 @@ void syr2k(
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<double> alpha,
-    std::complex<double> const *dA, int64_t ldda,
-    std::complex<double> const *dB, int64_t lddb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *dC, int64_t lddc,
-    blas::Queue &queue );
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
 
+//------------------------------------------------------------------------------
+void syrk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    float alpha,
+    float const* A, int64_t lda,
+    float beta,
+    float*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    double alpha,
+    double const* A, int64_t lda,
+    double beta,
+    double*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> beta,
+    std::complex<float>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    int64_t n, int64_t k,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> beta,
+    std::complex<double>*       C, int64_t ldc,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void trmm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       B, int64_t ldb,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void trsm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       B, int64_t ldb,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    blas::Side side,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t m,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       B, int64_t ldb,
+    blas::Queue& queue );
+
+//==============================================================================
+//                     Batch BLAS APIs (device)
+//==============================================================================
 namespace batch {
 
-// =============================================================================
+//==============================================================================
 // Level 1 Batch BLAS
 
-// =============================================================================
+//==============================================================================
 // Level 2 Batch BLAS
 
-// =============================================================================
+//==============================================================================
 // Level 3 Batch BLAS
-// -----------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
 // batch gemm
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<float >   const &alpha,
-    std::vector<float*>   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >   const &beta,
-    std::vector<float*>   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<double >  const &alpha,
-    std::vector<double*>  const &Aarray, std::vector<int64_t>  const &ldda,
-    std::vector<double*>  const &Barray, std::vector<int64_t>  const &lddb,
-    std::vector<double >  const &beta,
-    std::vector<double*>  const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<float>  >   const &alpha,
-    std::vector< std::complex<float>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<float>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<float>  >   const &beta,
-    std::vector< std::complex<float>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>  &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<double>  >   const &alpha,
-    std::vector< std::complex<double>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<double>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<double>  >   const &beta,
-    std::vector< std::complex<double>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+// batch gemm, group API
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    std::vector<size_t>     const& group_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                 layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<float >   const &alpha,
-    std::vector<float*>   const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<float*>   const &Barray,     std::vector<int64_t> const &lddb,
-    std::vector<float >   const &beta,
-    std::vector<float*>   const &Carray,     std::vector<int64_t> const &lddc,
-    std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    std::vector<size_t>     const& group_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                 layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<double >  const &alpha,
-    std::vector<double*>  const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<double*>  const &Barray,     std::vector<int64_t> const &lddb,
-    std::vector<double >  const &beta,
-    std::vector<double*>  const &Carray,     std::vector<int64_t> const &lddc,
-    std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    std::vector<size_t>     const& group_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void gemm(
-    blas::Layout                              layout,
-    std::vector<blas::Op>              const &transA,
-    std::vector<blas::Op>              const &transB,
-    std::vector<int64_t>               const &m,
-    std::vector<int64_t>               const &n,
-    std::vector<int64_t>               const &k,
-    std::vector<std::complex<float> >  const &alpha,
-    std::vector<std::complex<float>*>  const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>  const &Barray,     std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >  const &beta,
-    std::vector<std::complex<float>*>  const &Carray,     std::vector<int64_t> const &lddc,
-    std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    std::vector<size_t>     const& group_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
-void gemm(
-    blas::Layout                              layout,
-    std::vector<blas::Op>              const &transA,
-    std::vector<blas::Op>              const &transB,
-    std::vector<int64_t>               const &m,
-    std::vector<int64_t>               const &n,
-    std::vector<int64_t>               const &k,
-    std::vector<std::complex<double> >  const &alpha,
-    std::vector<std::complex<double>*>  const &Aarray,     std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>  const &Barray,     std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >  const &beta,
-    std::vector<std::complex<double>*>  const &Carray,     std::vector<int64_t> const &lddc,
-    std::vector<size_t>   const &group_size, std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// batch trsm
-void trsm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trsm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trsm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trsm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// batch trmm
-void trmm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void trmm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // batch hemm
 void hemm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void hemm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void hemm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void hemm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
-// batch symm
-void symm(
-    blas::Layout                  layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// batch herk
-void herk(
-    blas::Layout                  layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<float>       const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >      const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
-// batch syrk
-void syrk(
-    blas::Layout                  layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-void syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // batch her2k
 void her2k(
-    blas::Layout                  layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float>>      const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >                   const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double>>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >                   const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// batch herk
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< float >                const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< double >                const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+// batch symm
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 // batch syr2k
 void syr2k(
-    blas::Layout                  layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 void syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+// batch syrk
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+// batch trmm
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+// batch trsm
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue );
 
 }  // namespace batch
 }  // namespace blas

--- a/include/blas/wrappers.hh
+++ b/include/blas/wrappers.hh
@@ -11,1123 +11,1003 @@ namespace blas {
 
 #ifndef BLAS_USE_TEMPLATE
 
-// =============================================================================
+//==============================================================================
 // Level 1 BLAS
+// Alphabetical order
 
-// -----------------------------------------------------------------------------
-/// @ingroup asum
+//------------------------------------------------------------------------------
 float asum(
     int64_t n,
-    float const *x, int64_t incx );
+    float const* x, int64_t incx );
 
-/// @ingroup asum
 double asum(
     int64_t n,
-    double const *x, int64_t incx );
+    double const* x, int64_t incx );
 
-/// @ingroup asum
 float asum(
     int64_t n,
-    std::complex<float> const *x, int64_t incx );
+    std::complex<float> const* x, int64_t incx );
 
-/// @ingroup asum
 double asum(
     int64_t n,
-    std::complex<double> const *x, int64_t incx );
+    std::complex<double> const* x, int64_t incx );
 
-// -----------------------------------------------------------------------------
-/// @ingroup axpy
+//------------------------------------------------------------------------------
 void axpy(
     int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float       *y, int64_t incy );
+    float const* x, int64_t incx,
+    float*       y, int64_t incy );
 
-/// @ingroup axpy
 void axpy(
     int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double       *y, int64_t incy );
+    double const* x, int64_t incx,
+    double*       y, int64_t incy );
 
-/// @ingroup axpy
 void axpy(
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float>       *y, int64_t incy );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float>*       y, int64_t incy );
 
-/// @ingroup axpy
 void axpy(
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double>       *y, int64_t incy );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double>*       y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup copy
+//------------------------------------------------------------------------------
 void copy(
     int64_t n,
-    float const *x, int64_t incx,
-    float       *y, int64_t incy );
+    float const* x, int64_t incx,
+    float*       y, int64_t incy );
 
-/// @ingroup copy
 void copy(
     int64_t n,
-    double const *x, int64_t incx,
-    double       *y, int64_t incy );
+    double const* x, int64_t incx,
+    double*       y, int64_t incy );
 
-/// @ingroup copy
 void copy(
     int64_t n,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float>       *y, int64_t incy );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float>*       y, int64_t incy );
 
-/// @ingroup copy
 void copy(
     int64_t n,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double>       *y, int64_t incy );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double>*       y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup dot
+//------------------------------------------------------------------------------
 float dot(
     int64_t n,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy );
 
-/// @ingroup dot
 double dot(
     int64_t n,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy );
 
-/// @ingroup dot
 std::complex<float> dot(
     int64_t n,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy );
 
-/// @ingroup dot
 std::complex<double> dot(
     int64_t n,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup dotu
+//------------------------------------------------------------------------------
 float dotu(
     int64_t n,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy );
 
-/// @ingroup dotu
 double dotu(
     int64_t n,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy );
 
-/// @ingroup dotu
 std::complex<float> dotu(
     int64_t n,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy );
 
-/// @ingroup dotu
 std::complex<double> dotu(
     int64_t n,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup iamax
+//------------------------------------------------------------------------------
 int64_t iamax(
     int64_t n,
-    float const *x, int64_t incx );
+    float const* x, int64_t incx );
 
-/// @ingroup iamax
 int64_t iamax(
     int64_t n,
-    double const *x, int64_t incx );
+    double const* x, int64_t incx );
 
-/// @ingroup iamax
 int64_t iamax(
     int64_t n,
-    std::complex<float> const *x, int64_t incx );
+    std::complex<float> const* x, int64_t incx );
 
-/// @ingroup iamax
 int64_t iamax(
     int64_t n,
-    std::complex<double> const *x, int64_t incx );
+    std::complex<double> const* x, int64_t incx );
 
-// -----------------------------------------------------------------------------
-/// @ingroup nrm2
+//------------------------------------------------------------------------------
 float nrm2(
     int64_t n,
-    float const *x, int64_t incx );
+    float const* x, int64_t incx );
 
-/// @ingroup nrm2
 double nrm2(
     int64_t n,
-    double const *x, int64_t incx );
+    double const* x, int64_t incx );
 
-/// @ingroup nrm2
 float nrm2(
     int64_t n,
-    std::complex<float> const *x, int64_t incx );
+    std::complex<float> const* x, int64_t incx );
 
-/// @ingroup nrm2
 double nrm2(
     int64_t n,
-    std::complex<double> const *x, int64_t incx );
+    std::complex<double> const* x, int64_t incx );
 
-// -----------------------------------------------------------------------------
-/// @ingroup rot
+//------------------------------------------------------------------------------
 void rot(
     int64_t n,
-    float *x, int64_t incx,
-    float *y, int64_t incy,
+    float* x, int64_t incx,
+    float* y, int64_t incy,
     float c,
     float s );
 
-/// @ingroup rot
 void rot(
     int64_t n,
-    double *x, int64_t incx,
-    double *y, int64_t incy,
+    double* x, int64_t incx,
+    double* y, int64_t incy,
     double c,
     double s );
 
-/// @ingroup rot
 /// real cosine, real sine
 /// Applies a real Givens rotation (e.g., in real tridiagonal eig)
 /// to a complex matrix (e.g., complex eigenvectors).
 void rot(
     int64_t n,
-    std::complex<float> *x, int64_t incx,
-    std::complex<float> *y, int64_t incy,
+    std::complex<float>* x, int64_t incx,
+    std::complex<float>* y, int64_t incy,
     float c,
     float s );
 
-/// @ingroup rot
 /// real cosine, real sine
 /// Applies a real Givens rotation (e.g., in real tridiagonal eig)
 /// to a complex matrix (e.g., complex eigenvectors).
 void rot(
     int64_t n,
-    std::complex<double> *x, int64_t incx,
-    std::complex<double> *y, int64_t incy,
+    std::complex<double>* x, int64_t incx,
+    std::complex<double>* y, int64_t incy,
     double c,
     double s );
 
-/// @ingroup rot
 /// real cosine, complex sine
 /// Applies a complex Givens rotation to a complex matrix
 /// (e.g., in complex GMRES).
 void rot(
     int64_t n,
-    std::complex<float> *x, int64_t incx,
-    std::complex<float> *y, int64_t incy,
+    std::complex<float>* x, int64_t incx,
+    std::complex<float>* y, int64_t incy,
     float c,
     std::complex<float> s );
 
-/// @ingroup rot
 /// real cosine, complex sine
 /// Applies a complex Givens rotation to a complex matrix
 /// (e.g., in complex GMRES).
 void rot(
     int64_t n,
-    std::complex<double> *x, int64_t incx,
-    std::complex<double> *y, int64_t incy,
+    std::complex<double>* x, int64_t incx,
+    std::complex<double>* y, int64_t incy,
     double c,
     std::complex<double> s );
 
-// -----------------------------------------------------------------------------
-/// @ingroup rotg
+//------------------------------------------------------------------------------
 void rotg(
-    float *a,
-    float *b,
-    float *c,
-    float *s );
+    float* a,
+    float* b,
+    float* c,
+    float* s );
 
-/// @ingroup rotg
 void rotg(
-    double *a,
-    double *b,
-    double *c,
-    double *s );
+    double* a,
+    double* b,
+    double* c,
+    double* s );
 
-/// @ingroup rotg
 void rotg(
-    std::complex<float> *a,
-    std::complex<float> *b,  // const in BLAS implementation, oddly
-    float *c,
-    std::complex<float> *s );
+    std::complex<float>* a,
+    std::complex<float>* b,  // const in BLAS implementation, oddly
+    float* c,
+    std::complex<float>* s );
 
-/// @ingroup rotg
 void rotg(
-    std::complex<double> *a,
-    std::complex<double> *b,  // const in BLAS implementation, oddly
-    double *c,
-    std::complex<double> *s );
+    std::complex<double>* a,
+    std::complex<double>* b,  // const in BLAS implementation, oddly
+    double* c,
+    std::complex<double>* s );
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // only real
-/// @ingroup rotm
 void rotm(
     int64_t n,
-    float *x, int64_t incx,
-    float *y, int64_t incy,
+    float* x, int64_t incx,
+    float* y, int64_t incy,
     float const param[5] );
 
-/// @ingroup rotm
 void rotm(
     int64_t n,
-    double *x, int64_t incx,
-    double *y, int64_t incy,
+    double* x, int64_t incx,
+    double* y, int64_t incy,
     double const param[5] );
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // only real
-/// @ingroup rotmg
 void rotmg(
-    float *d1,
-    float *d2,
-    float *a,
+    float* d1,
+    float* d2,
+    float* a,
     float  b,
     float  param[5] );
 
-/// @ingroup rotmg
 void rotmg(
-    double *d1,
-    double *d2,
-    double *a,
+    double* d1,
+    double* d2,
+    double* a,
     double  b,
     double  param[5] );
 
-// -----------------------------------------------------------------------------
-/// @ingroup scal
+//------------------------------------------------------------------------------
 void scal(
     int64_t n,
     float alpha,
-    float *x, int64_t incx );
+    float* x, int64_t incx );
 
-/// @ingroup scal
 void scal(
     int64_t n,
     double alpha,
-    double *x, int64_t incx );
+    double* x, int64_t incx );
 
-/// @ingroup scal
 void scal(
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> *x, int64_t incx );
+    std::complex<float>* x, int64_t incx );
 
-/// @ingroup scal
 void scal(
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> *x, int64_t incx );
+    std::complex<double>* x, int64_t incx );
 
-// -----------------------------------------------------------------------------
-/// @ingroup swap
+//------------------------------------------------------------------------------
 void swap(
     int64_t n,
-    float *x, int64_t incx,
-    float *y, int64_t incy );
+    float* x, int64_t incx,
+    float* y, int64_t incy );
 
-/// @ingroup swap
 void swap(
     int64_t n,
-    double *x, int64_t incx,
-    double *y, int64_t incy );
+    double* x, int64_t incx,
+    double* y, int64_t incy );
 
-/// @ingroup swap
 void swap(
     int64_t n,
-    std::complex<float> *x, int64_t incx,
-    std::complex<float> *y, int64_t incy );
+    std::complex<float>* x, int64_t incx,
+    std::complex<float>* y, int64_t incy );
 
-/// @ingroup swap
 void swap(
     int64_t n,
-    std::complex<double> *x, int64_t incx,
-    std::complex<double> *y, int64_t incy );
+    std::complex<double>* x, int64_t incx,
+    std::complex<double>* y, int64_t incy );
 
-// =============================================================================
+//==============================================================================
 // Level 2 BLAS
 
-// -----------------------------------------------------------------------------
-/// @ingroup gemv
+//------------------------------------------------------------------------------
 void gemv(
     blas::Layout layout,
     blas::Op trans,
     int64_t m, int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float const *x, int64_t incx,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
     float beta,
-    float       *y, int64_t incy );
+    float*       y, int64_t incy );
 
-/// @ingroup gemv
 void gemv(
     blas::Layout layout,
     blas::Op trans,
     int64_t m, int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double const *x, int64_t incx,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
     double beta,
-    double       *y, int64_t incy );
+    double*       y, int64_t incy );
 
-/// @ingroup gemv
 void gemv(
     blas::Layout layout,
     blas::Op trans,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *x, int64_t incx,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
     std::complex<float> beta,
-    std::complex<float>       *y, int64_t incy );
+    std::complex<float>*       y, int64_t incy );
 
-/// @ingroup gemv
 void gemv(
     blas::Layout layout,
     blas::Op trans,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *x, int64_t incx,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
     std::complex<double> beta,
-    std::complex<double>       *y, int64_t incy );
+    std::complex<double>*       y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup ger
+//------------------------------------------------------------------------------
 void ger(
     blas::Layout layout,
     int64_t m, int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float*       A, int64_t lda );
 
-/// @ingroup ger
 void ger(
     blas::Layout layout,
     int64_t m, int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double*       A, int64_t lda );
 
-/// @ingroup ger
 void ger(
     blas::Layout layout,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float>       *A, int64_t lda );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>*       A, int64_t lda );
 
-/// @ingroup ger
 void ger(
     blas::Layout layout,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double>       *A, int64_t lda );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup geru
+//------------------------------------------------------------------------------
 void geru(
     blas::Layout layout,
     int64_t m, int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float*       A, int64_t lda );
 
-/// @ingroup geru
 void geru(
     blas::Layout layout,
     int64_t m, int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double*       A, int64_t lda );
 
-/// @ingroup geru
 void geru(
     blas::Layout layout,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float>       *A, int64_t lda );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>*       A, int64_t lda );
 
-/// @ingroup geru
 void geru(
     blas::Layout layout,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double>       *A, int64_t lda );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup hemv
+//------------------------------------------------------------------------------
 void hemv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float const *x, int64_t incx,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
     float beta,
-    float       *y, int64_t incy );
+    float*       y, int64_t incy );
 
-/// @ingroup hemv
 void hemv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double const *x, int64_t incx,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
     double beta,
-    double       *y, int64_t incy );
+    double*       y, int64_t incy );
 
-/// @ingroup hemv
 void hemv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *x, int64_t incx,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
     std::complex<float> beta,
-    std::complex<float>       *y, int64_t incy );
+    std::complex<float>*       y, int64_t incy );
 
-/// @ingroup hemv
 void hemv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *x, int64_t incx,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
     std::complex<double> beta,
-    std::complex<double>       *y, int64_t incy );
+    std::complex<double>*       y, int64_t incy );
 
-// -----------------------------------------------------------------------------
-/// @ingroup her
+//------------------------------------------------------------------------------
 void her(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float*       A, int64_t lda );
 
-/// @ingroup her
 void her(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double*       A, int64_t lda );
 
-/// @ingroup her
 void her(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float>       *A, int64_t lda );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float>*       A, int64_t lda );
 
-/// @ingroup her
 void her(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double>       *A, int64_t lda );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double>*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup her2
+//------------------------------------------------------------------------------
 void her2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float*       A, int64_t lda );
 
-/// @ingroup her2
 void her2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double*       A, int64_t lda );
 
-/// @ingroup her2
 void her2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float>       *A, int64_t lda );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>*       A, int64_t lda );
 
-/// @ingroup her2
 void her2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double>       *A, int64_t lda );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup symv
+//------------------------------------------------------------------------------
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float const *x, int64_t incx,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
     float beta,
-    float       *y, int64_t incy );
+    float*       y, int64_t incy );
 
-/// @ingroup symv
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double const *x, int64_t incx,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
     double beta,
-    double       *y, int64_t incy );
+    double*       y, int64_t incy );
 
-/// @ingroup symv
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *x, int64_t incx,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
     std::complex<float> beta,
-    std::complex<float>       *y, int64_t incy );
+    std::complex<float>*       y, int64_t incy );
 
-/// @ingroup symv
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *x, int64_t incx,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
     std::complex<double> beta,
-    std::complex<double>       *y, int64_t incy );
+    std::complex<double>*       y, int64_t incy );
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // only real; complex in lapack++
-/// @ingroup syr
 void syr(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float*       A, int64_t lda );
 
-/// @ingroup syr
 void syr(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup syr2
+//------------------------------------------------------------------------------
 void syr2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     float alpha,
-    float const *x, int64_t incx,
-    float const *y, int64_t incy,
-    float       *A, int64_t lda );
+    float const* x, int64_t incx,
+    float const* y, int64_t incy,
+    float*       A, int64_t lda );
 
-/// @ingroup syr2
 void syr2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     double alpha,
-    double const *x, int64_t incx,
-    double const *y, int64_t incy,
-    double       *A, int64_t lda );
+    double const* x, int64_t incx,
+    double const* y, int64_t incy,
+    double*       A, int64_t lda );
 
-/// @ingroup syr2
 void syr2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *x, int64_t incx,
-    std::complex<float> const *y, int64_t incy,
-    std::complex<float>       *A, int64_t lda );
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> const* y, int64_t incy,
+    std::complex<float>*       A, int64_t lda );
 
-/// @ingroup syr2
 void syr2(
     blas::Layout layout,
     blas::Uplo uplo,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *x, int64_t incx,
-    std::complex<double> const *y, int64_t incy,
-    std::complex<double>       *A, int64_t lda );
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> const* y, int64_t incy,
+    std::complex<double>*       A, int64_t lda );
 
-// -----------------------------------------------------------------------------
-/// @ingroup trmv
+//------------------------------------------------------------------------------
 void trmv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    float const *A, int64_t lda,
-    float       *x, int64_t incx );
+    float const* A, int64_t lda,
+    float*       x, int64_t incx );
 
-/// @ingroup trmv
 void trmv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    double const *A, int64_t lda,
-    double       *x, int64_t incx );
+    double const* A, int64_t lda,
+    double*       x, int64_t incx );
 
-/// @ingroup trmv
 void trmv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float>       *x, int64_t incx );
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx );
 
-/// @ingroup trmv
 void trmv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double>       *x, int64_t incx );
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx );
 
-// -----------------------------------------------------------------------------
-/// @ingroup trsv
+//------------------------------------------------------------------------------
 void trsv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    float const *A, int64_t lda,
-    float       *x, int64_t incx );
+    float const* A, int64_t lda,
+    float*       x, int64_t incx );
 
-/// @ingroup trsv
 void trsv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    double const *A, int64_t lda,
-    double       *x, int64_t incx );
+    double const* A, int64_t lda,
+    double*       x, int64_t incx );
 
-/// @ingroup trsv
 void trsv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float>       *x, int64_t incx );
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx );
 
-/// @ingroup trsv
 void trsv(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     blas::Diag diag,
     int64_t n,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double>       *x, int64_t incx );
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx );
 
-// =============================================================================
+//==============================================================================
 // Level 3 BLAS
 
-// -----------------------------------------------------------------------------
-/// @ingroup gemm
+//------------------------------------------------------------------------------
 void gemm(
     blas::Layout layout,
     blas::Op transA,
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     float alpha,
-    float const *A, int64_t lda,
-    float const *B, int64_t ldb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup gemm
 void gemm(
     blas::Layout layout,
     blas::Op transA,
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     double alpha,
-    double const *A, int64_t lda,
-    double const *B, int64_t ldb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup gemm
 void gemm(
     blas::Layout layout,
     blas::Op transA,
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *B, int64_t ldb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup gemm
 void gemm(
     blas::Layout layout,
     blas::Op transA,
     blas::Op transB,
     int64_t m, int64_t n, int64_t k,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *B, int64_t ldb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup hemm
+//------------------------------------------------------------------------------
 void hemm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float const *B, int64_t ldb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup hemm
 void hemm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double const *B, int64_t ldb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup hemm
 void hemm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *B, int64_t ldb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup hemm
 void hemm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *B, int64_t ldb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup her2k
+//------------------------------------------------------------------------------
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *A, int64_t lda,
-    float const *B, int64_t ldb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup her2k
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *A, int64_t lda,
-    double const *B, int64_t ldb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup her2k
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<float> alpha,  // note: complex
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *B, int64_t ldb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     float beta,   // note: real
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup her2k
 void her2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<double> alpha,  // note: complex
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *B, int64_t ldb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     double beta,  // note: real
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup herk
+//------------------------------------------------------------------------------
 void herk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *A, int64_t lda,
+    float const* A, int64_t lda,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup herk
 void herk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *A, int64_t lda,
+    double const* A, int64_t lda,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup herk
 void herk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,  // note: real
-    std::complex<float> const *A, int64_t lda,
+    std::complex<float> const* A, int64_t lda,
     float beta,   // note: real
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup herk
 void herk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    std::complex<double> const *A, int64_t lda,
+    std::complex<double> const* A, int64_t lda,
     double beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup symm
+//------------------------------------------------------------------------------
 void symm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float const *B, int64_t ldb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup symm
 void symm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double const *B, int64_t ldb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup symm
 void symm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *B, int64_t ldb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup symm
 void symm(
     blas::Layout layout,
     blas::Side side,
     blas::Uplo uplo,
     int64_t m, int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *B, int64_t ldb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup syr2k
+//------------------------------------------------------------------------------
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *A, int64_t lda,
-    float const *B, int64_t ldb,
+    float const* A, int64_t lda,
+    float const* B, int64_t ldb,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup syr2k
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *A, int64_t lda,
-    double const *B, int64_t ldb,
+    double const* A, int64_t lda,
+    double const* B, int64_t ldb,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup syr2k
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float> const *B, int64_t ldb,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* B, int64_t ldb,
     std::complex<float> beta,
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup syr2k
 void syr2k(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double> const *B, int64_t ldb,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* B, int64_t ldb,
     std::complex<double> beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup syrk
+//------------------------------------------------------------------------------
 void syrk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     float alpha,
-    float const *A, int64_t lda,
+    float const* A, int64_t lda,
     float beta,
-    float       *C, int64_t ldc );
+    float*       C, int64_t ldc );
 
-/// @ingroup syrk
 void syrk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     double alpha,
-    double const *A, int64_t lda,
+    double const* A, int64_t lda,
     double beta,
-    double       *C, int64_t ldc );
+    double*       C, int64_t ldc );
 
-/// @ingroup syrk
 void syrk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
+    std::complex<float> const* A, int64_t lda,
     std::complex<float> beta,
-    std::complex<float>       *C, int64_t ldc );
+    std::complex<float>*       C, int64_t ldc );
 
-/// @ingroup syrk
 void syrk(
     blas::Layout layout,
     blas::Uplo uplo,
     blas::Op trans,
     int64_t n, int64_t k,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
+    std::complex<double> const* A, int64_t lda,
     std::complex<double> beta,
-    std::complex<double>       *C, int64_t ldc );
+    std::complex<double>*       C, int64_t ldc );
 
-// -----------------------------------------------------------------------------
-/// @ingroup trmm
+//------------------------------------------------------------------------------
 void trmm(
     blas::Layout layout,
     blas::Side side,
@@ -1137,10 +1017,9 @@ void trmm(
     int64_t m,
     int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float       *B, int64_t ldb );
+    float const* A, int64_t lda,
+    float*       B, int64_t ldb );
 
-/// @ingroup trmm
 void trmm(
     blas::Layout layout,
     blas::Side side,
@@ -1150,10 +1029,9 @@ void trmm(
     int64_t m,
     int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double       *B, int64_t ldb );
+    double const* A, int64_t lda,
+    double*       B, int64_t ldb );
 
-/// @ingroup trmm
 void trmm(
     blas::Layout layout,
     blas::Side side,
@@ -1163,10 +1041,9 @@ void trmm(
     int64_t m,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float>       *B, int64_t ldb );
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       B, int64_t ldb );
 
-/// @ingroup trmm
 void trmm(
     blas::Layout layout,
     blas::Side side,
@@ -1176,11 +1053,10 @@ void trmm(
     int64_t m,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double>       *B, int64_t ldb );
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       B, int64_t ldb );
 
-// -----------------------------------------------------------------------------
-/// @ingroup trsm
+//------------------------------------------------------------------------------
 void trsm(
     blas::Layout layout,
     blas::Side side,
@@ -1190,10 +1066,9 @@ void trsm(
     int64_t m,
     int64_t n,
     float alpha,
-    float const *A, int64_t lda,
-    float       *B, int64_t ldb );
+    float const* A, int64_t lda,
+    float*       B, int64_t ldb );
 
-/// @ingroup trsm
 void trsm(
     blas::Layout layout,
     blas::Side side,
@@ -1203,10 +1078,9 @@ void trsm(
     int64_t m,
     int64_t n,
     double alpha,
-    double const *A, int64_t lda,
-    double       *B, int64_t ldb );
+    double const* A, int64_t lda,
+    double*       B, int64_t ldb );
 
-/// @ingroup trsm
 void trsm(
     blas::Layout layout,
     blas::Side side,
@@ -1216,10 +1090,9 @@ void trsm(
     int64_t m,
     int64_t n,
     std::complex<float> alpha,
-    std::complex<float> const *A, int64_t lda,
-    std::complex<float>       *B, int64_t ldb );
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       B, int64_t ldb );
 
-/// @ingroup trsm
 void trsm(
     blas::Layout layout,
     blas::Side side,
@@ -1229,497 +1102,542 @@ void trsm(
     int64_t m,
     int64_t n,
     std::complex<double> alpha,
-    std::complex<double> const *A, int64_t lda,
-    std::complex<double>       *B, int64_t ldb );
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       B, int64_t ldb );
 
 #endif  // BLAS_USE_TEMPLATE
 
-// =============================================================================
-//                     Batch BLAS APIs ( host )
-// =============================================================================
+//==============================================================================
+//                     Batch BLAS APIs (host)
+//==============================================================================
 namespace batch {
 
-// -----------------------------------------------------------------------------
+//==============================================================================
+// Level 1 Batch BLAS
+
+//==============================================================================
+// Level 2 Batch BLAS
+
+//==============================================================================
+// Level 3 Batch BLAS
+
+//------------------------------------------------------------------------------
 // batch gemm
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<float >   const &alpha,
-    std::vector<float*>   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >   const &beta,
-    std::vector<float*>   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<double >  const &alpha,
-    std::vector<double*>  const &Aarray, std::vector<int64_t>  const &ldda,
-    std::vector<double*>  const &Barray, std::vector<int64_t>  const &lddb,
-    std::vector<double >  const &beta,
-    std::vector<double*>  const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<float>  >   const &alpha,
-    std::vector< std::complex<float>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<float>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<float>  >   const &beta,
-    std::vector< std::complex<float>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>  &info );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<double>  >   const &alpha,
-    std::vector< std::complex<double>* >   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<double>* >   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<double>  >   const &beta,
-    std::vector< std::complex<double>* >   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
-// -----------------------------------------------------------------------------
-// batch trsm
-void trsm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void trsm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void trsm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void trsm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-// -----------------------------------------------------------------------------
-// batch trmm
-void trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // batch hemm
 void hemm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
-// -----------------------------------------------------------------------------
-// batch symm
-void symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void symm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void symm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void symm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-// -----------------------------------------------------------------------------
-// batch herk
-void herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void herk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void herk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<float>       const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >      const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
-
-void herk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
-
-// -----------------------------------------------------------------------------
-// batch syrk
-void syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
-
-void syrk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info );
-
-void syrk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
-
-void syrk(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
 // batch her2k
 void her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void her2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void her2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float>>      const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >                   const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void her2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double>>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >                   const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+// batch herk
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< float >                const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< double >                const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+//------------------------------------------------------------------------------
+// batch symm
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+//------------------------------------------------------------------------------
 // batch syr2k
 void syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void syr2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void syr2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 void syr2k(
-    blas::Layout                    layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info );
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+//------------------------------------------------------------------------------
+// batch syrk
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+//------------------------------------------------------------------------------
+// batch trmm
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+//------------------------------------------------------------------------------
+// batch trsm
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
+
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info );
 
 }  // namespace batch
 }  // namespace blas

--- a/src/batch_gemm.cc
+++ b/src/batch_gemm.cc
@@ -3,214 +3,167 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup gemm
-void blas::batch::gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<float >   const &alpha,
-    std::vector<float*>   const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>   const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >   const &beta,
-    std::vector<float*>   const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup gemm_internal
+///
+template <typename scalar_t>
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::gemm_check<float>( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
+        blas::batch::gemm_check(
+            layout, transA, transB, m, n, k,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Op transA_   = blas::batch::extract<Op>(transA, i);
-        Op transB_   = blas::batch::extract<Op>(transB, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::gemm(
-            layout, transA_, transB_, m_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Op   transA_ = blas::batch::extract( transA, i );
+        blas::Op   transB_ = blas::batch::extract( transB, i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::gemm( layout, transA_, transB_, m_, n_, k_,
+                    alpha_, A_, lda_, B_, ldb_, beta_,  C_, ldc_ );
     }
 }
 
-// -----------------------------------------------------------------------------
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
 /// @ingroup gemm
-void blas::batch::gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector<double >  const &alpha,
-    std::vector<double*>  const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>  const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >  const &beta,
-    std::vector<double*>  const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                  std::vector<int64_t>       &info )
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::gemm_check<double>( layout, transA, transB,
-                                         m, n, k,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         beta,  Carray, lddc,
-                                         batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Op transA_    = blas::batch::extract<Op>(transA, i);
-        Op transB_    = blas::batch::extract<Op>(transB, i);
-        int64_t m_    = blas::batch::extract<int64_t>(m, i);
-        int64_t n_    = blas::batch::extract<int64_t>(n, i);
-        int64_t k_    = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_  = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_  = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_  = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::gemm(
-            layout, transA_, transB_, m_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::gemm( layout, transA, transB, m, n, k,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup gemm
-void blas::batch::gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<float>  > const &alpha,
-    std::vector< std::complex<float>* > const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<float>* > const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<float>  > const &beta,
-    std::vector< std::complex<float>* > const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                std::vector<int64_t> &info )
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::gemm_check< std::complex<float> >( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Op transA_    = blas::batch::extract<Op>(transA, i);
-        Op transB_    = blas::batch::extract<Op>(transB, i);
-        int64_t m_    = blas::batch::extract<int64_t>(m, i);
-        int64_t n_    = blas::batch::extract<int64_t>(n, i);
-        int64_t k_    = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_  = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_  = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_  = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float> >(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float> >(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::gemm(
-            layout, transA_, transB_, m_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::gemm( layout, transA, transB, m, n, k,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup gemm
-void blas::batch::gemm(
-    blas::Layout                layout,
-    std::vector<blas::Op> const &transA,
-    std::vector<blas::Op> const &transB,
-    std::vector<int64_t>  const &m,
-    std::vector<int64_t>  const &n,
-    std::vector<int64_t>  const &k,
-    std::vector< std::complex<double>  > const &alpha,
-    std::vector< std::complex<double>* > const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector< std::complex<double>* > const &Barray, std::vector<int64_t> const &lddb,
-    std::vector< std::complex<double>  > const &beta,
-    std::vector< std::complex<double>* > const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                 std::vector<int64_t>       &info )
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::gemm_check< std::complex<double> >( layout, transA, transB,
-                                        m, n, k,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        beta,  Carray, lddc,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Op transA_    = blas::batch::extract<Op>(transA, i);
-        Op transB_    = blas::batch::extract<Op>(transB, i);
-        int64_t m_    = blas::batch::extract<int64_t>(m, i);
-        int64_t n_    = blas::batch::extract<int64_t>(n, i);
-        int64_t k_    = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_  = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_  = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_  = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double> >(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double> >(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::gemm(
-            layout, transA_, transB_, m_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-     }
+    impl::gemm( layout, transA, transB, m, n, k,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup gemm
+void gemm(
+    blas::Layout layout,
+    std::vector<blas::Op>   const& transA,
+    std::vector<blas::Op>   const& transB,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::gemm( layout, transA, transB, m, n, k,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_hemm.cc
+++ b/src/batch_hemm.cc
@@ -3,207 +3,161 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup hemm_internal
+///
+template <typename scalar_t>
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::hemm_check<float>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::hemm_check(
+            layout, side, uplo, m, n,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::hemm( layout, side_, uplo_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_, beta_,  C_, ldc_ );
     }
 }
 
-// -----------------------------------------------------------------------------
-/// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info )
-{
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<double>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
+}  // namespace impl
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
+/// @ingroup hemm
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>       &info )
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<std::complex<float>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<std::complex<double>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup hemm
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_herk.cc
+++ b/src/batch_herk.cc
@@ -3,187 +3,156 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup herk_internal
+///
+template <typename scalar_t>
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< real_type<scalar_t> > const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< real_type<scalar_t> > const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    using real_t = real_type<scalar_t>;
+
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::herk_check<float, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::herk_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        real_t     alpha_  = blas::batch::extract( alpha,  i );
+        real_t     beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::herk( layout, uplo_, trans_, n_, k_,
+                    alpha_, A_, lda_, beta_, C_, ldc_ );
     }
 }
 
-// -----------------------------------------------------------------------------
-/// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info )
-{
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<double, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
+}  // namespace impl
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
+/// @ingroup herk
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<float>       const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >      const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>       &info )
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<std::complex<float>, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< float >                const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<std::complex<double>, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup herk
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< double >                const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_symm.cc
+++ b/src/batch_symm.cc
@@ -3,207 +3,161 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup symm_internal
+///
+template <typename scalar_t>
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::symm_check<float>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::symm_check(
+            layout, side, uplo, m, n,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::symm( layout, side_, uplo_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_, beta_,  C_, ldc_ );
     }
 }
 
-// -----------------------------------------------------------------------------
-/// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info )
-{
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<double>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
+}  // namespace impl
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
+/// @ingroup symm
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                  std::vector<int64_t>       &info )
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<std::complex<float>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<std::complex<double>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup symm
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_syr2k.cc
+++ b/src/batch_syr2k.cc
@@ -3,207 +3,160 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup syr2k_internal
+///
+template <typename scalar_t>
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::syr2k_check<float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::syr2k_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::syr2k( layout, uplo_, trans_, n_, k_,
+                     alpha_, A_, lda_, B_, ldb_, beta_, C_, ldc_ );
     }
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
+/// @ingroup syr2k
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info );
 }
 
 // -----------------------------------------------------------------------------
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                              std::vector<int64_t>       &info )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<std::complex<float>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                               std::vector<int64_t>       &info )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<std::complex<double>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info );
 }
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_syrk.cc
+++ b/src/batch_syrk.cc
@@ -3,187 +3,154 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup syrk_internal
+///
+template <typename scalar_t>
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::syrk_check<float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::syrk_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, beta, Carray, ldc,
+            batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::syrk( layout, uplo_, trans_, n_, k_,
+                    alpha_, A_, lda_, beta_, C_, ldc_ );
     }
 }
 
-// -----------------------------------------------------------------------------
-/// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info )
-{
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
+}  // namespace impl
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
+/// @ingroup syrk
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                              std::vector<int64_t>       &info )
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<std::complex<float>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                               std::vector<int64_t>       &info )
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<std::complex<double>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_ );
-    }
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup syrk
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_trmm.cc
+++ b/src/batch_trmm.cc
@@ -3,195 +3,159 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup trmm_internal
+///
+template <typename scalar_t>
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::trmm_check<float>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
+        blas::batch::trmm_check(
+            layout, side, uplo, trans, diag, m, n,
+            alpha, Aarray, lda, Barray, ldb, batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        blas::Diag diag_   = blas::batch::extract( diag,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        blas::trmm( layout, side_, uplo_, trans_, diag_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_ );
     }
 }
 
+}  // namespace impl
 
-// -----------------------------------------------------------------------------
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<double>( layout, side, uplo, trans, diag,
-                                         m, n,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_ );
-    }
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
 
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                                  std::vector<int64_t>       &info )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<std::complex<float>>(
-                                        layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_ );
-    }
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<std::complex<double>>(
-                                        layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_ );
-    }
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup trmm
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/batch_trsm.cc
+++ b/src/batch_trsm.cc
@@ -3,196 +3,159 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
 #include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup trsm
-void blas::batch::trsm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup trsm_internal
+///
+template <typename scalar_t>
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::trsm_check<float>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
+        blas::batch::trsm_check(
+            layout, side, uplo, trans, diag, m, n,
+            alpha, Aarray, lda, Barray, ldb, batch_size, info );
     }
 
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-       Side side_   = blas::batch::extract<Side>(side, i);
-       Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-       Op   trans_  = blas::batch::extract<Op>(trans, i);
-       Diag diag_   = blas::batch::extract<Diag>(diag, i);
-       int64_t m_   = blas::batch::extract<int64_t>(m, i);
-       int64_t n_   = blas::batch::extract<int64_t>(n, i);
-       int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-       int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-       float alpha_ = blas::batch::extract<float>(alpha, i);
-       float* dA_   = blas::batch::extract<float*>(Aarray, i);
-       float* dB_   = blas::batch::extract<float*>(Barray, i);
-       blas::trsm(
-           layout, side_, uplo_, trans_, diag_, m_, n_,
-           alpha_, dA_, lda_,
-                   dB_, ldb_ );
+    #pragma omp parallel for schedule( dynamic )
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        blas::Diag diag_   = blas::batch::extract( diag,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        blas::trsm( layout, side_, uplo_, trans_, diag_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_ );
     }
 }
 
+}  // namespace impl
 
-// -----------------------------------------------------------------------------
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, float version.
 /// @ingroup trsm
-void blas::batch::trsm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info )
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trsm_check<double>( layout, side, uplo, trans, diag,
-                                         m, n,
-                                         alpha, Aarray, ldda,
-                                                Barray, lddb,
-                                         batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-       Side side_   = blas::batch::extract<Side>(side, i);
-       Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-       Op   trans_  = blas::batch::extract<Op>(trans, i);
-       Diag diag_   = blas::batch::extract<Diag>(diag, i);
-       int64_t m_   = blas::batch::extract<int64_t>(m, i);
-       int64_t n_   = blas::batch::extract<int64_t>(n, i);
-       int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-       int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-       double alpha_ = blas::batch::extract<double>(alpha, i);
-       double* dA_   = blas::batch::extract<double*>(Aarray, i);
-       double* dB_   = blas::batch::extract<double*>(Barray, i);
-       blas::trsm(
-           layout, side_, uplo_, trans_, diag_, m_, n_,
-           alpha_, dA_, lda_,
-                   dB_, ldb_ );
-    }
+    impl::trsm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
 
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, double version.
 /// @ingroup trsm
-void blas::batch::trsm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                                  std::vector<int64_t>       &info )
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trsm_check<std::complex<float>>(
-                                        layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-       Side side_   = blas::batch::extract<Side>(side, i);
-       Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-       Op   trans_  = blas::batch::extract<Op>(trans, i);
-       Diag diag_   = blas::batch::extract<Diag>(diag, i);
-       int64_t m_   = blas::batch::extract<int64_t>(m, i);
-       int64_t n_   = blas::batch::extract<int64_t>(n, i);
-       int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-       int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-       std::complex<float> alpha_ = blas::batch::extract<std::complex<float> >(alpha, i);
-       std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-       std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-       blas::trsm(
-           layout, side_, uplo_, trans_, diag_, m_, n_,
-           alpha_, dA_, lda_,
-                   dB_, ldb_ );
-    }
+    impl::trsm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
 
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<float> version.
 /// @ingroup trsm
-void blas::batch::trsm(
-    blas::Layout                layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                                   std::vector<int64_t>       &info )
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
 {
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trsm_check<std::complex<double>>(
-                                        layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    #pragma omp parallel for schedule(dynamic)
-    for (size_t i = 0; i < batch; ++i) {
-       Side side_   = blas::batch::extract<Side>(side, i);
-       Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-       Op   trans_  = blas::batch::extract<Op>(trans, i);
-       Diag diag_   = blas::batch::extract<Diag>(diag, i);
-       int64_t m_   = blas::batch::extract<int64_t>(m, i);
-       int64_t n_   = blas::batch::extract<int64_t>(n, i);
-       int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-       int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-       std::complex<double> alpha_ = blas::batch::extract<std::complex<double> >(alpha, i);
-       std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-       std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-       blas::trsm(
-           layout, side_, uplo_, trans_, diag_, m_, n_,
-           alpha_, dA_, lda_,
-                   dB_, ldb_ );
-    }
+    impl::trsm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
 }
+
+//------------------------------------------------------------------------------
+/// CPU, variable-size batched, complex<double> version.
+/// @ingroup trsm
+void trsm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info )
+{
+    impl::trsm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info );
+}
+
+}  // namespace batch
+}  // namespace blas


### PR DESCRIPTION
Refactors batch routines, same way as PR #18.
Also reformats the headers to alphabetize routines and minimize diff when doing:
```
meld include/blas/wrappers.hh include/blas/device_blas.hh
```
This builds on PR #21.