### PR TITLE
Refactor GPU device batch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ add_library(
     src/trsv.cc
     src/version.cc
     src/device_batch_gemm.cc
+    src/device_batch_gemm_group.cc
     src/device_batch_hemm.cc
     src/device_batch_her2k.cc
     src/device_batch_herk.cc

--- a/src/device_batch_hemm.cc
+++ b/src/device_batch_hemm.cc
@@ -6,228 +6,171 @@
 #include <limits>
 #include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
+
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
 
 //------------------------------------------------------------------------------
-/// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup hemm_internal
+///
+template <typename scalar_t>
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::hemm_check<float>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::hemm_check(
+            layout, side, uplo, m, n,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::hemm( layout, side_, uplo_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_, beta_, C_, ldc_,
+                    queue );
         queue.revolve();
     }
     queue.join();
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
+/// @ingroup hemm
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
 //------------------------------------------------------------------------------
+/// GPU device, variable-size batched, double version.
 /// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<double>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
 //------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<std::complex<float>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
 //------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
 /// @ingroup hemm
-void blas::batch::hemm(
-    blas::Layout                    layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void hemm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::hemm_check<std::complex<double>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::hemm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::hemm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_her2k.cc
+++ b/src/device_batch_her2k.cc
@@ -3,231 +3,172 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup her2k
-void blas::batch::her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup her2k_internal
+///
+template <typename scalar_t>
+void her2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< real_type<scalar_t> > const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
+    using real_t = real_type<scalar_t>;
+
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::her2k_check<float, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::her2k_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::her2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        real_t     beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::her2k( layout, uplo_, trans_, n_, k_,
+                     alpha_, A_, lda_, B_, ldb_, beta_, C_, ldc_,
+                     queue );
         queue.revolve();
     }
     queue.join();
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
+/// @ingroup her2k
+void her2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::her2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
 // -----------------------------------------------------------------------------
 /// @ingroup her2k
-void blas::batch::her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void her2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::her2k_check<double, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::her2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::her2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup her2k
-void blas::batch::her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float>>      const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >                   const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void her2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::her2k_check<std::complex<float>, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        float               beta_  = blas::batch::extract<float>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::her2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::her2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
 /// @ingroup her2k
-void blas::batch::her2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double>>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >                   const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void her2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::her2k_check<std::complex<double>, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        double               beta_  = blas::batch::extract<double>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::her2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::her2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_herk.cc
+++ b/src/device_batch_herk.cc
@@ -3,211 +3,167 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup herk_internal
+///
+template <typename scalar_t>
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< real_type<scalar_t> > const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< real_type<scalar_t> > const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
+    using real_t = real_type<scalar_t>;
+
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::herk_check<float, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::herk_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        real_t     alpha_  = blas::batch::extract( alpha,  i );
+        real_t     beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::herk( layout, uplo_, trans_, n_, k_,
+                    alpha_, A_, lda_, beta_, C_, ldc_,
+                    queue );
         queue.revolve();
     }
     queue.join();
 }
 
-// -----------------------------------------------------------------------------
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
 /// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<double, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, double version.
 /// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<float>       const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >      const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<std::complex<float>, float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup herk
-void blas::batch::herk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double>      const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< float >                const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< float >                const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::herk_check<std::complex<double>, double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::herk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
+/// @ingroup herk
+void herk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< double >                const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< double >                const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::herk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_symm.cc
+++ b/src/device_batch_symm.cc
@@ -3,231 +3,171 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup symm_internal
+///
+template <typename scalar_t>
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::symm_check<float>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::symm_check(
+            layout, side, uplo, m, n,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::symm( layout, side_, uplo_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_, beta_,  C_, ldc_,
+                    queue );
         queue.revolve();
     }
     queue.join();
 }
 
-// -----------------------------------------------------------------------------
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
 /// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<double>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, double version.
 /// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> >     const &beta,
-    std::vector<std::complex<float>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<std::complex<float>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup symm
-void blas::batch::symm(
-    blas::Layout                   layout,
-    std::vector<blas::Side>  const &side,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<int64_t>     const &m,
-    std::vector<int64_t>     const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> >     const &beta,
-    std::vector<std::complex<double>*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::symm_check<std::complex<double>>(
-                        layout, side, uplo,
-                        m, n,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::symm(
-            layout, side_, uplo_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
 }
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
+/// @ingroup symm
+void symm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::symm( layout, side, uplo, m, n,
+                alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                batch_size, info, queue );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_syr2k.cc
+++ b/src/device_batch_syr2k.cc
@@ -3,231 +3,170 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup syr2k_internal
+///
+template <typename scalar_t>
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::syr2k_check<float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::syr2k_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::syr2k( layout, uplo_, trans_, n_, k_,
+                     alpha_, A_, lda_, B_, ldb_, beta_, C_, ldc_,
+                     queue );
         queue.revolve();
     }
     queue.join();
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
+/// @ingroup syr2k
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
 // -----------------------------------------------------------------------------
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<std::complex<float>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
 /// @ingroup syr2k
-void blas::batch::syr2k(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*> const &Barray, std::vector<int64_t> const &lddb,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syr2k(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syr2k_check<std::complex<double>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                               Barray, lddb,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::syr2k(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syr2k( layout, uplo, trans, n, k,
+                 alpha, Aarray, lda, Barray, ldb, beta, Carray, ldc,
+                 batch_size, info, queue );
 }
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_syrk.cc
+++ b/src/device_batch_syrk.cc
@@ -3,211 +3,164 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<int64_t>    const &n,
-    std::vector<int64_t>    const &k,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float >     const &beta,
-    std::vector<float*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup syrk_internal
+///
+template <typename scalar_t>
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t >  const& beta,
+    std::vector<scalar_t*>  const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::syrk_check<float>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
+        blas::batch::syrk_check(
+            layout, uplo, trans, n, k,
+            alpha, Aarray, lda, beta, Carray, ldc,
+            batch_size, info );
     }
 
     blas::internal_set_device( queue.device() );
 
     queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float beta_  = blas::batch::extract<float>(beta, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dC_   = blas::batch::extract<float*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    k_      = blas::batch::extract( k,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldc_    = blas::batch::extract( ldc,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t   beta_   = blas::batch::extract( beta,   i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  C_      = blas::batch::extract( Carray, i );
+        blas::syrk( layout, uplo_, trans_, n_, k_,
+                    alpha_, A_, lda_, beta_, C_, ldc_, queue );
         queue.revolve();
     }
     queue.join();
 }
 
-// -----------------------------------------------------------------------------
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
 /// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double >     const &beta,
-    std::vector<double*>     const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float >     const& beta,
+    std::vector<float*>     const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<double>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double beta_  = blas::batch::extract<double>(beta, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dC_   = blas::batch::extract<double*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, double version.
 /// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<float> > const &alpha,
-    std::vector<std::complex<float>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float> > const &beta,
-    std::vector<std::complex<float>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double >    const& beta,
+    std::vector<double*>    const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<std::complex<float>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float> beta_  = blas::batch::extract<std::complex<float>>(beta, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dC_   = blas::batch::extract<std::complex<float>*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup syrk
-void blas::batch::syrk(
-    blas::Layout                   layout,
-    std::vector<blas::Uplo>  const &uplo,
-    std::vector<blas::Op>    const &trans,
-    std::vector<int64_t>     const &n,
-    std::vector<int64_t>     const &k,
-    std::vector<std::complex<double> > const &alpha,
-    std::vector<std::complex<double>*> const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double> > const &beta,
-    std::vector<std::complex<double>*> const &Carray, std::vector<int64_t> const &lddc,
-    const size_t batch, std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>  > const& beta,
+    std::vector< std::complex<float>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::syrk_check<std::complex<double>>(
-                        layout, uplo, trans,
-                        n, k,
-                        alpha, Aarray, ldda,
-                        beta,  Carray, lddc,
-                        batch, info );
-    }
-
-    blas::internal_set_device( queue.device() );
-
-    queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t k_   = blas::batch::extract<int64_t>(k, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldc_ = blas::batch::extract<int64_t>(lddc, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double> beta_  = blas::batch::extract<std::complex<double>>(beta, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dC_   = blas::batch::extract<std::complex<double>*>(Carray, i);
-        blas::syrk(
-            layout, uplo_, trans_, n_, k_,
-            alpha_, dA_, lda_,
-            beta_,  dC_, ldc_, queue );
-        queue.revolve();
-    }
-    queue.join();
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
 }
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
+/// @ingroup syrk
+void syrk(
+    blas::Layout layout,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<int64_t>    const& n,
+    std::vector<int64_t>    const& k,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>  > const& beta,
+    std::vector< std::complex<double>* > const& Carray, std::vector<int64_t> const& ldc,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::syrk( layout, uplo, trans, n, k,
+                alpha, Aarray, lda, beta, Carray, ldc,
+                batch_size, info, queue );
+}
+
+}  // namespace batch
+}  // namespace blas

--- a/src/device_batch_trmm.cc
+++ b/src/device_batch_trmm.cc
@@ -3,37 +3,48 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#include <limits>
-#include <cstring>
 #include "blas/batch_common.hh"
-#include "blas/device_blas.hh"
+#include "blas.hh"
 
-// -----------------------------------------------------------------------------
-/// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<float >     const &alpha,
-    std::vector<float*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<float*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                    std::vector<int64_t>       &info,
-    blas::Queue &queue )
+#include <limits>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched version.
+/// Mid-level templated wrapper checks and converts arguments,
+/// then makes individual routine calls in parallel.
+/// @ingroup trmm_internal
+///
+template <typename scalar_t>
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<scalar_t >  const& alpha,
+    std::vector<scalar_t*>  const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<scalar_t*>  const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
+    blas_error_if( batch_size < 0 );
+    blas_error_if( info.size() != 0
+                   && info.size() != 1
+                   && info.size() != batch_size );
     if (info.size() > 0) {
         // perform error checking
-        blas::batch::trmm_check<float>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
+        blas::batch::trmm_check(
+            layout, side, uplo, trans, diag, m, n,
+            alpha, Aarray, lda, Barray, ldb, batch_size, info );
     }
 
     // rocm 4.0 seems to have bug with trmm when using multiple streams.
@@ -47,22 +58,20 @@ void blas::batch::trmm(
 
     if (fork)
         queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        float alpha_ = blas::batch::extract<float>(alpha, i);
-        float* dA_   = blas::batch::extract<float*>(Aarray, i);
-        float* dB_   = blas::batch::extract<float*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_, queue );
+    for (size_t i = 0; i < batch_size; ++i) {
+        blas::Side side_   = blas::batch::extract( side,   i );
+        blas::Uplo uplo_   = blas::batch::extract( uplo,   i );
+        blas::Op   trans_  = blas::batch::extract( trans,  i );
+        blas::Diag diag_   = blas::batch::extract( diag,   i );
+        int64_t    m_      = blas::batch::extract( m,      i );
+        int64_t    n_      = blas::batch::extract( n,      i );
+        int64_t    lda_    = blas::batch::extract( lda,    i );
+        int64_t    ldb_    = blas::batch::extract( ldb,    i );
+        scalar_t   alpha_  = blas::batch::extract( alpha,  i );
+        scalar_t*  A_      = blas::batch::extract( Aarray, i );
+        scalar_t*  B_      = blas::batch::extract( Barray, i );
+        blas::trmm( layout, side_, uplo_, trans_, diag_, m_, n_,
+                    alpha_, A_, lda_, B_, ldb_, queue );
         if (fork)
             queue.revolve();
     }
@@ -70,190 +79,103 @@ void blas::batch::trmm(
         queue.join();
 }
 
+}  // namespace impl
 
-// -----------------------------------------------------------------------------
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+namespace batch {
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, float version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<double >     const &alpha,
-    std::vector<double*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<double*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<float >     const& alpha,
+    std::vector<float*>     const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<float*>     const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<double>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    // rocm 4.0 seems to have bug with trmm when using multiple streams.
-    #ifdef BLAS_HAVE_ROCBLAS
-        const bool fork = false;
-    #else
-        const bool fork = true;
-    #endif
-
-    blas::internal_set_device( queue.device() );
-
-    if (fork)
-        queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        double alpha_ = blas::batch::extract<double>(alpha, i);
-        double* dA_   = blas::batch::extract<double*>(Aarray, i);
-        double* dB_   = blas::batch::extract<double*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_, queue );
-        if (fork)
-            queue.revolve();
-    }
-    if (fork)
-        queue.join();
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info, queue );
 }
 
-
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, double version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<float> >     const &alpha,
-    std::vector<std::complex<float>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<float>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector<double >    const& alpha,
+    std::vector<double*>    const& Aarray, std::vector<int64_t> const& lda,
+    std::vector<double*>    const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<std::complex<float>>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    // rocm 4.0 seems to have bug with trmm when using multiple streams.
-    #ifdef BLAS_HAVE_ROCBLAS
-        const bool fork = false;
-    #else
-        const bool fork = true;
-    #endif
-
-    blas::internal_set_device( queue.device() );
-
-    if (fork)
-        queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        std::complex<float> alpha_ = blas::batch::extract<std::complex<float>>(alpha, i);
-        std::complex<float>* dA_   = blas::batch::extract<std::complex<float>*>(Aarray, i);
-        std::complex<float>* dB_   = blas::batch::extract<std::complex<float>*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_, queue );
-        if (fork)
-            queue.revolve();
-    }
-    if (fork)
-        queue.join();
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info, queue );
 }
 
-// -----------------------------------------------------------------------------
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<float> version.
 /// @ingroup trmm
-void blas::batch::trmm(
-    blas::Layout                   layout,
-    std::vector<blas::Side> const &side,
-    std::vector<blas::Uplo> const &uplo,
-    std::vector<blas::Op>   const &trans,
-    std::vector<blas::Diag> const &diag,
-    std::vector<int64_t>    const &m,
-    std::vector<int64_t>    const &n,
-    std::vector<std::complex<double> >     const &alpha,
-    std::vector<std::complex<double>*>     const &Aarray, std::vector<int64_t> const &ldda,
-    std::vector<std::complex<double>*>     const &Barray, std::vector<int64_t> const &lddb,
-    const size_t batch,                     std::vector<int64_t>       &info,
-    blas::Queue &queue )
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<float>  > const& alpha,
+    std::vector< std::complex<float>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<float>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
 {
-    blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
-    blas_error_if( batch < 0 );
-    blas_error_if( ! (info.size() == 0 || info.size() == 1 || info.size() == batch) );
-    if (info.size() > 0) {
-        // perform error checking
-        blas::batch::trmm_check<std::complex<double>>( layout, side, uplo, trans, diag,
-                                        m, n,
-                                        alpha, Aarray, ldda,
-                                               Barray, lddb,
-                                        batch, info );
-    }
-
-    // rocm 4.0 seems to have bug with trmm when using multiple streams.
-    #ifdef BLAS_HAVE_ROCBLAS
-        const bool fork = false;
-    #else
-        const bool fork = true;
-    #endif
-
-    blas::internal_set_device( queue.device() );
-
-    if (fork)
-        queue.fork();
-    for (size_t i = 0; i < batch; ++i) {
-        Side side_   = blas::batch::extract<Side>(side, i);
-        Uplo uplo_   = blas::batch::extract<Uplo>(uplo, i);
-        Op   trans_  = blas::batch::extract<Op>(trans, i);
-        Diag diag_   = blas::batch::extract<Diag>(diag, i);
-        int64_t m_   = blas::batch::extract<int64_t>(m, i);
-        int64_t n_   = blas::batch::extract<int64_t>(n, i);
-        int64_t lda_ = blas::batch::extract<int64_t>(ldda, i);
-        int64_t ldb_ = blas::batch::extract<int64_t>(lddb, i);
-        std::complex<double> alpha_ = blas::batch::extract<std::complex<double>>(alpha, i);
-        std::complex<double>* dA_   = blas::batch::extract<std::complex<double>*>(Aarray, i);
-        std::complex<double>* dB_   = blas::batch::extract<std::complex<double>*>(Barray, i);
-        blas::trmm(
-            layout, side_, uplo_, trans_, diag_, m_, n_,
-            alpha_, dA_, lda_,
-                    dB_, ldb_, queue );
-        if (fork)
-            queue.revolve();
-    }
-    if (fork)
-        queue.join();
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info, queue );
 }
+
+//------------------------------------------------------------------------------
+/// GPU device, variable-size batched, complex<double> version.
+/// @ingroup trmm
+void trmm(
+    blas::Layout layout,
+    std::vector<blas::Side> const& side,
+    std::vector<blas::Uplo> const& uplo,
+    std::vector<blas::Op>   const& trans,
+    std::vector<blas::Diag> const& diag,
+    std::vector<int64_t>    const& m,
+    std::vector<int64_t>    const& n,
+    std::vector< std::complex<double>  > const& alpha,
+    std::vector< std::complex<double>* > const& Aarray, std::vector<int64_t> const& lda,
+    std::vector< std::complex<double>* > const& Barray, std::vector<int64_t> const& ldb,
+    size_t batch_size,
+    std::vector<int64_t>& info,
+    blas::Queue& queue )
+{
+    impl::trmm( layout, side, uplo, trans, diag, m, n,
+                alpha, Aarray, lda, Barray, ldb,
+                batch_size, info, queue );
+}
+
+}  // namespace batch
+}  // namespace blas


### PR DESCRIPTION
Refactors GPU device batch routines, same way as PR https://github.com/icl-utk-edu/blaspp/pull/22.

This builds on PR https://github.com/icl-utk-edu/blaspp/pull/22.

For reviewing code, I recommend comparing against the CPU implementation (from PR #22):
```
# Fetch branch from my repo.
git fetch -f https://github.com/mgates3/blaspp.git refactor-dev-batch:refactor-dev-batch
git checkout refactor-dev-batch

# Copy CPU batch BLAS files to tmp2 directory.
mkdir tmp2
cp src/batch*.cc tmp2/

# Rename files with "device_" prefix and apply simple code transformations.
cd tmp2
for x in *.cc ; do mv $x device_$x ; done

perl -pi -e 's/CPU,/GPU device,/' *.cc
cd ..

# Compare directories. Under meld's "File Filters", I uncheck "New" to ignore new files.
# Could also use Xcode's opendiff. In that case, check "Added/Deleted" to ignore new files.
meld tmp2 src
```
Fixed-size batched gemm and trsm call GPU-native routines. Other routines and variable-size batch gemm and trsm use a multi-stream implementation, basically replacing `#pragma omp parallel for` with `queue.fork() ... queue.revolve(); ... queue.join();`.