### PR TITLE
add data type options to examples for smoke test

### DIFF
--- a/example/example_gemm.cc
+++ b/example/example_gemm.cc
@@ -99,16 +99,34 @@ void test_device_gemm( int m, int n, int k )
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    int m = 100, n = 200, k = 50;
-    test_gemm< float  >( m, n, k );
-    test_gemm< double >( m, n, k );
-    test_gemm< std::complex<float>  >( m, n, k );
-    test_gemm< std::complex<double> >( m, n, k );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
 
-    test_device_gemm< float  >( m, n, k );
-    test_device_gemm< double >( m, n, k );
-    test_device_gemm< std::complex<float>  >( m, n, k );
-    test_device_gemm< std::complex<double> >( m, n, k );
+        // Run tests.
+        int m = 100, n = 200, k = 50;
+        if (types[ 0 ])
+            test_gemm< float  >( m, n, k );
+        if (types[ 1 ])
+            test_gemm< double >( m, n, k );
+        if (types[ 2 ])
+            test_gemm< std::complex<float>  >( m, n, k );
+        if (types[ 3 ])
+            test_gemm< std::complex<double> >( m, n, k );
 
+        if (types[ 0 ])
+            test_device_gemm< float  >( m, n, k );
+        if (types[ 1 ])
+            test_device_gemm< double >( m, n, k );
+        if (types[ 2 ])
+            test_device_gemm< std::complex<float>  >( m, n, k );
+        if (types[ 3 ])
+            test_device_gemm< std::complex<double> >( m, n, k );
+    }
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
     return 0;
 }

--- a/example/example_util.cc
+++ b/example/example_util.cc
@@ -53,8 +53,25 @@ void test_util( scalar_type alpha )
 //------------------------------------------------------------------------------
 int main( int argc, char** argv )
 {
-    test_util(  float(1.234) );
-    test_util( double(2.468) );
-    test_util( std::complex< float>( 3.1415, 0.5678 ) );
-    test_util( std::complex<double>( 6.2830, 1.1356 ) );
+    try {
+        // Parse command line to set types for s, d, c, z precisions.
+        bool types[ 4 ];
+        parse_args( argc, argv, types );
+
+        // Run tests.
+        int m = 100, n = 200, k = 50;
+        if (types[ 0 ])
+            test_util(  float(1.234) );
+        if (types[ 1 ])
+            test_util( double(2.468) );
+        if (types[ 2 ])
+            test_util( std::complex< float>( 3.1415, 0.5678 ) );
+        if (types[ 3 ])
+            test_util( std::complex<double>( 6.2830, 1.1356 ) );
+    }
+    catch (std::exception const& ex) {
+        fprintf( stderr, "%s", ex.what() );
+        return 1;
+    }
+    return 0;
 }

--- a/example/util.hh
+++ b/example/util.hh
@@ -6,6 +6,9 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdio.h>
+#include <stdexcept>
+
 //------------------------------------------------------------------------------
 void print_func_( const char* func )
 {
@@ -17,5 +20,40 @@ void print_func_( const char* func )
 #else
     #define print_func() print_func_( __func__ )
 #endif
+
+//------------------------------------------------------------------------------
+// Parse command line options:
+// s = single,         sets types[ 0 ]
+// d = double,         sets types[ 1 ]
+// c = complex,        sets types[ 2 ]
+// z = double-complex, sets types[ 3 ]
+// If no options, sets all types to true.
+// Throws error for unknown options.
+void parse_args( int argc, char** argv, bool types[ 4 ] )
+{
+    if (argc == 1) {
+        types[ 0 ] = types[ 1 ] = types[ 2 ] = types[ 3 ] = true;
+    }
+    else {
+        types[ 0 ] = types[ 1 ] = types[ 2 ] = types[ 3 ] = false;
+    }
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[ i ];
+        if (arg == "s")
+            types[ 0 ] = true;
+        else if (arg == "d")
+            types[ 1 ] = true;
+        else if (arg == "c")
+            types[ 2 ] = true;
+        else if (arg == "z")
+            types[ 3 ] = true;
+        else {
+            throw std::runtime_error(
+                "unknown option: \"" + arg + "\"\n"
+                + "Usage: " + argv[ 0 ] + " [s] [d] [c] [z]\n"
+                + "for single, double, complex, double-complex.\n" );
+        }
+    }
+}
 
 #endif // UTIL_H


### PR DESCRIPTION
Some GPUs don't support double precision, so we need control over which precisions are run in smoke tests. This adds command line options to select precisions. To run only single and single-complex:
```
./example_gemm s c
./example_util s c
```