### PR TITLE
For SYCL/OneMKL, update dev-dot, dev-dotu, dev-nrm2 to allow cpu-malloc result pointers.

### DIFF
--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -238,7 +238,7 @@ private:
         sycl::event  default_event_;
 
         // pointer to current stream (default or fork mode)
-        sycl::queue *current_stream_;
+        // sycl::queue *current_stream_; // not currently used
 
     #else
         // pointer to current stream (default or fork mode)

--- a/src/blas_internal.hh
+++ b/src/blas_internal.hh
@@ -16,7 +16,7 @@ namespace blas {
 inline blas_int to_blas_int_( int64_t x, const char* x_str )
 {
     if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if_msg( x > std::numeric_limits<blas_int>::max(), x_str );
+        blas_error_if_msg( x > std::numeric_limits<blas_int>::max(), "%s", x_str );
     }
     return blas_int( x );
 }

--- a/src/device_dot.cc
+++ b/src/device_dot.cc
@@ -44,7 +44,21 @@ void dot(
     blas::internal_set_device( queue.device() );
 
     // call low-level wrapper
+    #if defined( BLAS_HAVE_ONEMKL )
+    sycl::queue syclq = queue.stream();
+    // check how the result scalar was allocated
+    auto result_ptr_type = sycl::get_pointer_type( result, syclq.get_context() );
+    if ( result_ptr_type == sycl::usm::alloc::unknown ) {
+        // if result was outside SYCL/USM memory allocation
+        scalar_t* result_dev = blas::device_malloc<scalar_t>( 1, queue );
+        internal::dot( n_, x, incx_, y, incy_, result_dev, queue );
+        blas::device_memcpy( result, result_dev, 1, queue );
+    } else {
+        internal::dot( n_, x, incx_, y, incy_, result, queue );
+    }
+    #else // other devices (CUDA/HIP)
     internal::dot( n_, x, incx_, y, incy_, result, queue );
+    #endif
 #endif
 }
 
@@ -78,7 +92,21 @@ void dotu(
     blas::internal_set_device( queue.device() );
 
     // call low-level wrapper
+    #if defined( BLAS_HAVE_ONEMKL )
+    sycl::queue syclq = queue.stream();
+    // check how the result scalar was allocated
+    auto result_ptr_type = sycl::get_pointer_type( result, syclq.get_context() );
+    if ( result_ptr_type == sycl::usm::alloc::unknown ) {
+        // if result was outside SYCL/USM memory allocation
+        scalar_t* result_dev = blas::device_malloc<scalar_t>( 1, queue );
+        internal::dotu( n_, x, incx_, y, incy_, result_dev, queue );
+        blas::device_memcpy( result, result_dev, 1, queue );
+    } else {
+        internal::dotu( n_, x, incx_, y, incy_, result, queue );
+    }
+    #else // other devices (CUDA/HIP)
     internal::dotu( n_, x, incx_, y, incy_, result, queue );
+    #endif
 #endif
 }
 

--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -19,7 +19,7 @@ inline device_blas_int to_device_blas_int_( int64_t x, const char* x_str )
 {
     if (sizeof(int64_t) > sizeof(device_blas_int)) {
         blas_error_if_msg( std::abs( x ) > std::numeric_limits<device_blas_int>::max(),
-                           x_str );
+                           "%s", x_str );
     }
     return device_blas_int( x );
 }

--- a/src/device_nrm2.cc
+++ b/src/device_nrm2.cc
@@ -41,19 +41,22 @@ void nrm2(
 
     // call low-level wrapper
     #if defined( BLAS_HAVE_ONEMKL )
-    sycl::queue syclq = queue.stream();
-    // check how the result scalar was allocated
-    auto result_ptr_type = sycl::get_pointer_type( result, syclq.get_context() );
-    if ( result_ptr_type == sycl::usm::alloc::unknown ) {
-        // if result was outside SYCL/USM memory allocation
-        real_type<scalar_t>* result_dev = blas::device_malloc< real_type<scalar_t> >( 1, queue );
-        internal::nrm2( n_, x, incx_, result_dev, queue );
-        blas::device_memcpy( result, result_dev, 1, queue );
-    } else {
-        internal::nrm2( n_, x, incx_, result, queue );
-    }
+        sycl::queue syclq = queue.stream();
+        // check how the result scalar was allocated
+        auto result_ptr_type = sycl::get_pointer_type( result, syclq.get_context() );
+        // if result was outside SYCL/USM memory allocation, use device workspace
+        if (result_ptr_type == sycl::usm::alloc::unknown) {
+            // use preallocated device workspace (resizing if needed)
+            queue.work_resize< char >( sizeof(scalar_t) );  // syncs if needed
+            real_type<scalar_t>* dev_work = (real_type<scalar_t>*)queue.work();
+            internal::nrm2( n_, x, incx_, dev_work, queue );
+            blas::device_memcpy( result, dev_work, 1, queue );
+        }
+        else {
+            internal::nrm2( n_, x, incx_, result, queue );
+        }
     #else // other devices (CUDA/HIP)
-    internal::nrm2( n_, x, incx_, result, queue );
+        internal::nrm2( n_, x, incx_, result, queue );
     #endif
 #endif
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -23,8 +23,8 @@ using testsweeper::ansi_normal;
 
 const double no_data = testsweeper::no_data_flag;
 
-const ParamType PT_Value  = ParamType::Value;
-const ParamType PT_List   = ParamType::List;
+// const ParamType PT_Value  = ParamType::Value; currently unused
+// const ParamType PT_List   = ParamType::List; currently unused
 const ParamType PT_Output = ParamType::Output;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
For SYCL the dev-dot, dev-dotu, dev-nrm2 need to be updated (need to check the result pointer, and if it was cpu-malloc'ed, then create a temporary result_dev to hold the result).  
```
./tester  --type s,d,c,z --dim 100 --incx 1,-1 --incy 1,-1 --pointer-mode h,d dev-dot
./tester  --type s,d,c,z --dim 100 --incx 1,-1 --incy 1,-1 --pointer-mode h,d dev-dotu
./tester  --type s,d,c,z --dim 100 --incx 1 --pointer-mode h,d dev-nrm2
```
These tests used to fail with `--pointer-mode h`  but all pass now.
