### PR TITLE
fix: remove compilation warning on Frontier

### DIFF
--- a/src/blas_internal.hh
+++ b/src/blas_internal.hh
@@ -16,7 +16,7 @@ namespace blas {
 inline blas_int to_blas_int_( int64_t x, const char* x_str )
 {
     if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if_msg( x > std::numeric_limits<blas_int>::max(), x_str );
+        blas_error_if_msg( x > std::numeric_limits<blas_int>::max(), "%s", x_str );
     }
     return blas_int( x );
 }

--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -19,7 +19,7 @@ inline device_blas_int to_device_blas_int_( int64_t x, const char* x_str )
 {
     if (sizeof(int64_t) > sizeof(device_blas_int)) {
         blas_error_if_msg( std::abs( x ) > std::numeric_limits<device_blas_int>::max(),
-                           x_str );
+                           "%s", x_str );
     }
     return device_blas_int( x );
 }

--- a/test/test.cc
+++ b/test/test.cc
@@ -23,8 +23,6 @@ using testsweeper::ansi_normal;
 
 const double no_data = testsweeper::no_data_flag;
 
-const ParamType PT_Value  = ParamType::Value;
-const ParamType PT_List   = ParamType::List;
 const ParamType PT_Output = ParamType::Output;
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
Some warning are generated on Frontier.

This PR removes these warning.

***Question:
 should I rebase to the latest first?