### PR TITLE
test: add --start option

### DIFF
--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -392,9 +392,10 @@ if (opts.aux):
     ]
 
 # ------------------------------------------------------------------------------
-# when output is redirected to file instead of TTY console,
-# print extra messages to stderr on TTY console.
-output_redirected = not sys.stdout.isatty()
+# When stdout is redirected to file instead of TTY console,
+# and  stderr is still going to a TTY console,
+# print extra summary messages to stderr.
+output_redirected = sys.stderr.isatty() and not sys.stdout.isatty()
 
 # ------------------------------------------------------------------------------
 # if output is redirected, prints to both stderr and stdout;

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -40,6 +40,7 @@ group_test.add_argument( '-t', '--test', action='store',
     help='test command to run, e.g., --test "mpirun -np 4 ./test"; default "%(default)s"',
     default='./tester' )
 group_test.add_argument( '--xml', help='generate report.xml for jenkins' )
+group_test.add_argument( '--start',   action='store', help='routine to start with, helpful for restarting', default='' )
 
 group_size = parser.add_argument_group( 'matrix dimensions (default is medium)' )
 group_size.add_argument(       '--quick',  action='store_true', help='run quick "sanity check" of few, small tests' )
@@ -131,6 +132,8 @@ if (opts.device):
     for c in categories:
         if (c.endswith('_device')):
             opts.__dict__[ c ] = True
+
+start_routine = opts.start
 
 # ------------------------------------------------------------------------------
 # parameters
@@ -460,6 +463,11 @@ run_all = (ntests == 0)
 seen = set()
 for cmd in cmds:
     if (run_all or cmd[0] in opts.tests):
+        if (start_routine and cmd[0] != start_routine):
+            print_tee( 'skipping', cmd[0] )
+            continue
+        start_routine = None
+
         seen.add( cmd[0] )
         (err, output) = run_test( cmd )
         if (err):

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -42,18 +42,19 @@ group_test.add_argument( '-t', '--test', action='store',
 group_test.add_argument( '--xml', help='generate report.xml for jenkins' )
 group_test.add_argument( '--dry-run', action='store_true', help='print commands, but do not execute them' )
 group_test.add_argument( '--start',   action='store', help='routine to start with, helpful for restarting', default='' )
+group_test.add_argument( '-x', '--exclude', action='append', help='routines to exclude; repeatable', default=[] )
 
 group_size = parser.add_argument_group( 'matrix dimensions (default is medium)' )
-group_size.add_argument(       '--quick',  action='store_true', help='run quick "sanity check" of few, small tests' )
-group_size.add_argument( '-x', '--xsmall', action='store_true', help='run x-small tests' )
-group_size.add_argument( '-s', '--small',  action='store_true', help='run small tests' )
-group_size.add_argument( '-m', '--medium', action='store_true', help='run medium tests' )
-group_size.add_argument( '-l', '--large',  action='store_true', help='run large tests' )
-group_size.add_argument(       '--square', action='store_true', help='run square (m = n = k) tests', default=False )
-group_size.add_argument(       '--tall',   action='store_true', help='run tall (m > n) tests', default=False )
-group_size.add_argument(       '--wide',   action='store_true', help='run wide (m < n) tests', default=False )
-group_size.add_argument(       '--mnk',    action='store_true', help='run tests with m, n, k all different', default=False )
-group_size.add_argument(       '--dim',    action='store',      help='explicitly specify size', default='' )
+group_size.add_argument( '--quick',  action='store_true', help='run quick "sanity check" of few, small tests' )
+group_size.add_argument( '--xsmall', action='store_true', help='run x-small tests' )
+group_size.add_argument( '--small',  action='store_true', help='run small tests' )
+group_size.add_argument( '--medium', action='store_true', help='run medium tests' )
+group_size.add_argument( '--large',  action='store_true', help='run large tests' )
+group_size.add_argument( '--square', action='store_true', help='run square (m = n = k) tests', default=False )
+group_size.add_argument( '--tall',   action='store_true', help='run tall (m > n) tests', default=False )
+group_size.add_argument( '--wide',   action='store_true', help='run wide (m < n) tests', default=False )
+group_size.add_argument( '--mnk',    action='store_true', help='run tests with m, n, k all different', default=False )
+group_size.add_argument( '--dim',    action='store',      help='explicitly specify size', default='' )
 
 group_cat = parser.add_argument_group( 'category (default is all)' )
 categories = [
@@ -467,7 +468,7 @@ run_all = (ntests == 0)
 
 seen = set()
 for cmd in cmds:
-    if (run_all or cmd[0] in opts.tests):
+    if ((run_all or cmd[0] in opts.tests) and cmd[0] not in opts.exclude):
         if (start_routine and cmd[0] != start_routine):
             print_tee( 'skipping', cmd[0] )
             continue
@@ -479,8 +480,8 @@ for cmd in cmds:
             failed_tests.append( (cmd[0], err, output) )
         else:
             passed_tests.append( cmd[0] )
-not_seen = list( filter( lambda x: x not in seen, opts.tests ) )
 
+not_seen = list( filter( lambda x: x not in seen, opts.tests ) )
 if (not_seen):
     print_tee( 'Warning: unknown routines:', ' '.join( not_seen ))
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -40,6 +40,7 @@ group_test.add_argument( '-t', '--test', action='store',
     help='test command to run, e.g., --test "mpirun -np 4 ./test"; default "%(default)s"',
     default='./tester' )
 group_test.add_argument( '--xml', help='generate report.xml for jenkins' )
+group_test.add_argument( '--dry-run', action='store_true', help='print commands, but do not execute them' )
 group_test.add_argument( '--start',   action='store', help='routine to start with, helpful for restarting', default='' )
 
 group_size = parser.add_argument_group( 'matrix dimensions (default is medium)' )
@@ -411,6 +412,9 @@ def print_tee( *args ):
 def run_test( cmd ):
     cmd = opts.test +' '+ cmd[1] +' '+ cmd[0]
     print_tee( cmd )
+    if (opts.dry_run):
+        return (None, None)
+
     output = ''
     p = subprocess.Popen( cmd.split(), stdout=subprocess.PIPE,
                                        stderr=subprocess.STDOUT )


### PR DESCRIPTION
Helpful to restart an interrupted run, or after fixing an issue with a routine. Example use:
```
frontier08753 blaspp/test> ./run_tests.py --device > device.txt
Wed Mar  8 11:23:37 2023
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2,-1,-2 --incy 1,2,-1,-2 dev-axpy
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2,-1,-2 --incy 1,2,-1,-2 dev-dot
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2,-1,-2 --incy 1,2,-1,-2 dev-dotu
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2 dev-nrm2
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2 dev-scal
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2,-1,-2 --incy 1,2,-1,-2 dev-swap
pass
./tester  --type s,d,c,z --dim 100:500:100 --incx 1,2,-1,-2 --incy 1,2,-1,-2 dev-copy
pass
./tester  --type s,d,c,z --layout c,r --align 32 --transA n,t,c --transB n,t,c --dim 100:500:100 --dim 200:1000:200x100:500:100 --dim 100:500:100x200:1000:200 --dim 100x300x600 --dim 300x100x600 --dim 100x600x300 --dim 300x600x100 --dim 600x100x300 --dim 600x300x100 dev-gemm
salloc: Job 1281585 has exceeded its time limit and its allocation has been revoked.

frontier08727 blaspp/test> ./run_tests.py --device --start dev-gemm >> device.txt
Wed Mar  8 12:01:17 2023
skipping dev-axpy
skipping dev-dot
skipping dev-dotu
skipping dev-nrm2
skipping dev-scal
skipping dev-swap
skipping dev-copy
./tester  --type s,d,c,z --layout c,r --align 32 --transA n,t,c --transB n,t,c --dim 100:500:100 --dim 200:1000:200x100:500:100 --dim 100:500:100x200:1000:200 --dim 100x300x600 --dim 300x100x600 --dim 100x600x300 --dim 300x600x100 --dim 600x100x300 --dim 600x300x100 dev-gemm
pass
./tester  --type s,d,c,z --align 32 --dim 512x512x32:64:32 --format l,t schur-gemm
pass
...
```