### PR TITLE
Change installation directory of CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,7 +463,7 @@ include( GNUInstallDirs )
 if (WIN32)
     set( install_configdir "blaspp" )
 else()
-    set( install_configdir "${CMAKE_INSTALL_LIBDIR}/blaspp" )
+    set( install_configdir "${CMAKE_INSTALL_LIBDIR}/cmake/blaspp" )
 endif()
 
 # Install library and add to <package>Targets.cmake


### PR DESCRIPTION
The CMake configuration files normally go into `${CMAKE_INSTALL_LIBDIR}/cmake/<lib-name>`, which conforms the CMake practice.

Ref: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/8111