### PR TITLE
Add guard around `omp.h`

### DIFF
--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -9,7 +9,9 @@
 #include "blas/device.hh"
 
 #include <complex>
+#ifdef _OPENMP
 #include <omp.h>
+#endif
 
 namespace blas {
 


### PR DESCRIPTION
It's unclear whether the header is needed at all (the code builds fine without), but just in case, this guards the `omp.h` header inclusion for compilers that do not support OMP