### PR TITLE
search for ROCm or CUDA

### DIFF
--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -52,8 +52,6 @@ if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     export CUDA_HOME=/usr/local/cuda/
     export PATH=${PATH}:${CUDA_HOME}/bin
-    #export CPATH=${CPATH}:${CUDA_HOME}/include
-    #export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
     export gpu_backend=cuda
     quiet which nvcc
     nvcc --version
@@ -62,9 +60,6 @@ fi
 if [ "${device}" = "gpu_amd" ]; then
     print "======================================== Load ROCm"
     export PATH=${PATH}:/opt/rocm/bin
-    #export CPATH=${CPATH}:/opt/rocm/include
-    #export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
-    #export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
     export gpu_backend=hip
     quiet which hipcc
     hipcc --version

--- a/.github/workflows/setup_env.sh
+++ b/.github/workflows/setup_env.sh
@@ -52,8 +52,8 @@ if [ "${device}" = "gpu_nvidia" ]; then
     print "======================================== Load CUDA"
     export CUDA_HOME=/usr/local/cuda/
     export PATH=${PATH}:${CUDA_HOME}/bin
-    export CPATH=${CPATH}:${CUDA_HOME}/include
-    export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
+    #export CPATH=${CPATH}:${CUDA_HOME}/include
+    #export LIBRARY_PATH=${LIBRARY_PATH}:${CUDA_HOME}/lib64
     export gpu_backend=cuda
     quiet which nvcc
     nvcc --version
@@ -62,9 +62,9 @@ fi
 if [ "${device}" = "gpu_amd" ]; then
     print "======================================== Load ROCm"
     export PATH=${PATH}:/opt/rocm/bin
-    export CPATH=${CPATH}:/opt/rocm/include
-    export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
+    #export CPATH=${CPATH}:/opt/rocm/include
+    #export LIBRARY_PATH=${LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
+    #export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/opt/rocm/lib:/opt/rocm/lib64
     export gpu_backend=hip
     quiet which hipcc
     hipcc --version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,9 @@ These include:
     LIBRARY_PATH        compile-time library search path
     LD_LIBRARY_PATH     runtime library search path
     DYLD_LIBRARY_PATH   runtime library search path on macOS
+    CUDA_PATH           path to CUDA, e.g., /usr/local/cuda
+    CUDA_HOME           also recognized for path to CUDA
+    ROCM_PATH           path to ROCm, e.g., /opt/rocm
 
 
 Options (Makefile and CMake)

--- a/config/config.py
+++ b/config/config.py
@@ -641,12 +641,14 @@ def cublas_library():
 
     if (cuda_path):
         incdir = os.path.join( cuda_path, 'include' )
-        cxxflags += ' -I' + incdir
+        if (os.path.exists( incdir )):
+            cxxflags += ' -I' + incdir
 
         libdir = os.path.join( cuda_path, 'lib64' )
         if (not os.path.exists( libdir )):
             libdir = os.path.join( cuda_path, 'lib' )
-        ldflags += '-L' + libdir + ' -Wl,-rpath,' + libdir
+        if (os.path.exists( libdir )):
+            ldflags += '-L' + libdir + ' -Wl,-rpath,' + libdir
     # end
 
     print_subhead( 'CUDA and cuBLAS libraries' )
@@ -683,14 +685,16 @@ def rocblas_library():
 
     if (rocm_path):
         incdir = os.path.join( rocm_path, 'include' )
-        cxxflags += ' -I' + incdir
+        if (os.path.exists( incdir )):
+            cxxflags += ' -I' + incdir
 
         # Some versions of ROCm (5.1.3) have both lib and lib64 directories;
         # we need the lib directory.
         libdir = os.path.join( rocm_path, 'lib' )
         if (not os.path.exists( libdir )):
             libdir = os.path.join( rocm_path, 'lib64' )
-        ldflags += ' -L' + libdir + ' -Wl,-rpath,' + libdir
+        if (os.path.exists( libdir )):
+            ldflags += ' -L' + libdir + ' -Wl,-rpath,' + libdir
     # end
 
     print_subhead( 'HIP/ROCm and rocBLAS libraries' )


### PR DESCRIPTION
Instead of requiring the user to add CUDA and ROCm to CFLAGS, LIBRARY_PATH, LD_LIBRARY_PATH, this does a quick search for them and adds the appropriate `-I`, `-L`, and `-rpath` flags. (CMake already does this.)

Similar changes are in SLATE and LAPACK++. The BLAS++ changes will need to be merged first, then LAPACK++, then SLATE submodules updated.