### PR TITLE
Fix smoke test example and config

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -35,6 +35,7 @@ ${TESTER} --batch-blas3-device          --xml ${top}/report-${maker}-batch-devic
 
 print "======================================== Smoke tests"
 cd ${top}/example
+export CXXFLAGS="-Werror"
 
 if [ "${maker}" = "make" ]; then
     export PKG_CONFIG_PATH=${top}/install/lib/pkgconfig

--- a/config/blas.cc
+++ b/config/blas.cc
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+//------------------------------------------------------------------------------
 #define BLAS_ddot FORTRAN_NAME( ddot, DDOT )
 
 // result return directly
@@ -19,6 +20,7 @@ double BLAS_ddot(
     const double* x, const blas_int* incx,
     const double* y, const blas_int* incy );
 
+//------------------------------------------------------------------------------
 int main()
 {
     // If blas_int is 32-bit, but BLAS actually interprets it as 64-bit,
@@ -28,7 +30,15 @@ int main()
     blas_int n[] = { 5, 5 }, ione = 1;
     double x[] = { 1, 2, 3, 4, 5 };
     double y[] = { 5, 4, 3, 2, 1 };
+    for (int i = 0; i < n[0]; ++i) {
+        printf( "x[ %d ] = %.1f; y[ %d ] = %.1f\n",
+                i, x[ i ],
+                i, y[ i ] );
+    }
+
     double result = BLAS_ddot( n, x, &ione, y, &ione );
+    printf( "result = %.1f; should be 35.0\n", result );
+
     bool okay = (result == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/config/cblas.cc
+++ b/config/cblas.cc
@@ -37,12 +37,21 @@
     #endif
 #endif
 
+//------------------------------------------------------------------------------
 int main()
 {
     int n = 5;
     double x[] = { 1, 2, 3, 4, 5 };
     double y[] = { 5, 4, 3, 2, 1 };
+    for (int i = 0; i < n; ++i) {
+        printf( "x[ %d ] = %.1f; y[ %d ] = %.1f\n",
+                i, x[ i ],
+                i, y[ i ] );
+    }
+
     double result = cblas_ddot( n, x, 1, y, 1 );
+    printf( "result = %.1f; should be 35.0\n", result );
+
     bool okay = (result == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/config/lapack.py
+++ b/config/lapack.py
@@ -22,14 +22,6 @@ def get_fortran_manglings():
     Ex: get_fortran_manglings()
     returns ['-D<name>_FORTRAN_ADD_', '-D<name>_FORTRAN_LOWER', '-D<name>_FORTRAN_UPPER']
     '''
-    # Warn about obsolete settings.
-    if (config.environ['fortran_add_']):
-        print_warn('Variable `fortran_add_`  is obsolete; use fortran_mangling=add_')
-    if (config.environ['fortran_lower']):
-        print_warn('Variable `fortran_lower` is obsolete; use fortran_mangling=lower')
-    if (config.environ['fortran_upper']):
-        print_warn('Variable `fortran_upper` is obsolete; use fortran_mangling=upper')
-
     # FORTRAN_ADD_, FORTRAN_LOWER, DFORTRAN_UPPER are BLAS++/LAPACK++.
     manglings = []
     fortran_mangling = config.environ['fortran_mangling'].lower()
@@ -151,22 +143,6 @@ def blas():
     '''
     print_header( 'BLAS library' )
     print_msg( 'Also detects Fortran name mangling and BLAS integer size.' )
-
-    # Warn about obsolete settings.
-    if (config.environ['mkl']):
-        print_warn('Variable `mkl`  is obsolete; use blas=mkl')
-    if (config.environ['acml']):
-        print_warn('Variable `acml` is obsolete; use blas=acml')
-    if (config.environ['essl']):
-        print_warn('Variable `essl` is obsolete; use blas=essl')
-    if (config.environ['openblas']):
-        print_warn('Variable `openblas` is obsolete; use blas=openblas')
-    if (config.environ['accelerate']):
-        print_warn('Variable `accelerate` is obsolete; use blas=accelerate')
-    if (config.environ['lp64']):
-        print_warn('Variable `lp64` is obsolete; use blas_int=int')
-    if (config.environ['ilp64']):
-        print_warn('Variable `ilp64` is obsolete; use blas_int=int64')
 
     #----------------------------------------
     # Parse options.

--- a/config/lapack.py
+++ b/config/lapack.py
@@ -559,7 +559,7 @@ def blas_float_return():
     if (rc == 0):
         config.environ.append( 'CXXFLAGS', define('HAVE_F2C') )
     else:
-        print_warn( 'unexpected error!' )
+        raise Error( "Could not determine return type of sdot; check log." )
 # end
 
 #-------------------------------------------------------------------------------
@@ -580,7 +580,7 @@ def blas_complex_return():
     if (rc == 0):
         config.environ.append( 'CXXFLAGS', define('COMPLEX_RETURN_ARGUMENT') )
     else:
-        print_warn( 'unexpected error!' )
+        raise Error( "Could not determine how zdot returns complex result; check log." )
 # end
 
 #-------------------------------------------------------------------------------

--- a/config/return_complex.cc
+++ b/config/return_complex.cc
@@ -6,25 +6,40 @@
 #include <stdio.h>
 #include <complex>
 
+// Use C99 _Complex as return type to be compatible with extern C linkage.
+#include <complex.h>
+
 #include "config.h"
 
+//------------------------------------------------------------------------------
 #define BLAS_zdotc FORTRAN_NAME( zdotc, ZDOTC )
 
 // result return directly
 #ifdef __cplusplus
 extern "C"
 #endif
-std::complex<double> BLAS_zdotc(
+double _Complex BLAS_zdotc(
     const blas_int* n,
     const std::complex<double>* x, const blas_int* incx,
     const std::complex<double>* y, const blas_int* incy );
 
+//------------------------------------------------------------------------------
 int main()
 {
     blas_int n = 5, ione = 1;
     std::complex<double> x[] = { 1, 2, 3, 4, 5 };
     std::complex<double> y[] = { 5, 4, 3, 2, 1 };
-    std::complex<double> result = BLAS_zdotc( &n, x, &ione, y, &ione );
+    for (int i = 0; i < n; ++i) {
+        printf( "x[ %d ] = %.1f + %.1fi; y[ %d ] = %.1f + %.1fi\n",
+                i, real( x[ i ] ), imag( x[ i ] ),
+                i, real( y[ i ] ), imag( y[ i ] ) );
+    }
+
+    double _Complex r = BLAS_zdotc( &n, x, &ione, y, &ione );
+    std::complex<double> result = *reinterpret_cast< std::complex<double>* >( &r );
+    printf( "result = %.1f + %.1fi; should be 35.0 + 0.0i\n",
+            real( result ), imag( result ) );
+
     bool okay = (real(result) == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/config/return_complex_argument.cc
+++ b/config/return_complex_argument.cc
@@ -8,6 +8,7 @@
 
 #include "config.h"
 
+//------------------------------------------------------------------------------
 #define BLAS_zdotc FORTRAN_NAME( zdotc, ZDOTC )
 
 // result returned as *hidden argument*
@@ -20,13 +21,23 @@ void BLAS_zdotc(
     const std::complex<double>* x, const blas_int* incx,
     const std::complex<double>* y, const blas_int* incy );
 
+//------------------------------------------------------------------------------
 int main()
 {
     blas_int n = 5, ione = 1;
     std::complex<double> x[] = { 1, 2, 3, 4, 5 };
     std::complex<double> y[] = { 5, 4, 3, 2, 1 };
+    for (int i = 0; i < n; ++i) {
+        printf( "x[ %d ] = %.1f + %.1fi; y[ %d ] = %.1f + %.1fi\n",
+                i, real( x[ i ] ), imag( x[ i ] ),
+                i, real( y[ i ] ), imag( y[ i ] ) );
+    }
+
     std::complex<double> result;
     BLAS_zdotc( &result, &n, x, &ione, y, &ione );
+    printf( "result = %.1f + %.1fi; should be 35.0 + 0.0i\n",
+            real( result ), imag( result ) );
+
     bool okay = (real(result) == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/config/return_float.cc
+++ b/config/return_float.cc
@@ -7,6 +7,7 @@
 
 #include "config.h"
 
+//------------------------------------------------------------------------------
 #define BLAS_sdot FORTRAN_NAME( sdot, SDOT )
 
 // returns *float*
@@ -17,12 +18,21 @@ float  BLAS_sdot( const blas_int* n,
                   const float* x, const blas_int* incx,
                   const float* y, const blas_int* incy );
 
+//------------------------------------------------------------------------------
 int main()
 {
     blas_int n = 5, ione = 1;
     float x[] = { 1, 2, 3, 4, 5 };
     float y[] = { 5, 4, 3, 2, 1 };
+    for (int i = 0; i < n; ++i) {
+        printf( "x[ %d ] = %.1f; y[ %d ] = %.1f\n",
+                i, x[ i ],
+                i, y[ i ] );
+    }
+
     float result = BLAS_sdot( &n, x, &ione, y, &ione );
+    printf( "result = %.1f; should be 35.0\n", result );
+
     bool okay = (result == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/config/return_float_f2c.cc
+++ b/config/return_float_f2c.cc
@@ -7,6 +7,7 @@
 
 #include "config.h"
 
+//------------------------------------------------------------------------------
 #define BLAS_sdot FORTRAN_NAME( sdot, SDOT )
 
 // returns *double*
@@ -17,12 +18,21 @@ double BLAS_sdot( const blas_int* n,
                   const float* x, const blas_int* incx,
                   const float* y, const blas_int* incy );
 
+//------------------------------------------------------------------------------
 int main()
 {
     blas_int n = 5, ione = 1;
     float x[] = { 1, 2, 3, 4, 5 };
     float y[] = { 5, 4, 3, 2, 1 };
+    for (int i = 0; i < n; ++i) {
+        printf( "x[ %d ] = %.1f; y[ %d ] = %.1f\n",
+                i, x[ i ],
+                i, y[ i ] );
+    }
+
     float result = BLAS_sdot( &n, x, &ione, y, &ione );
+    printf( "result = %.1f; should be 35.0\n", result );
+
     bool okay = (result == 35);
     printf( "%s\n", okay ? "ok" : "failed" );
     return ! okay;

--- a/example/example_gemm.cc
+++ b/example/example_gemm.cc
@@ -52,8 +52,7 @@ void test_device_gemm( int m, int n, int k )
         // ... fill in application data into A, B, C ...
 
         int device = 0;
-        int batch_size = 1000;  // todo: use default batch_size
-        blas::Queue queue( device, batch_size );
+        blas::Queue queue( device );
 
         T *dA = blas::device_malloc<T>( lda*k, queue );  // m-by-k
         T *dB = blas::device_malloc<T>( ldb*n, queue );  // k-by-n


### PR DESCRIPTION
3 minor updates:

- Update `example_gemm.cc` to match Queue revisions. It was printing "deprecated" warnings. Also flag such warnings as errors in CI.

- Use `_Complex` as return type for `zdotc` in config. clang++ was raising errors with extern C linkage. Also add some output to help debugging when users report issues.

- Remove some obsolete settings from 2020.

I highlighted these 3 things in GitHub conversations in the code.