### PR TITLE
Use typedef instead of #define. Use int64_t to be unambiguous.

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -18,6 +18,16 @@ print "======================================== Setup build"
 export color=no
 export CXXFLAGS="-Werror -Wno-unused-command-line-argument"
 
+# Test int64 build with make/cuda and cmake/amd.
+# Test int32 build with cmake/cuda and make/amd and all others.
+if [ "${maker}" = "make" -a "${device}" = "gpu_nvidia" ]; then
+    export blas_int=int64
+elif [ "${maker}" = "cmake" -a "${device}" = "gpu_amd" ]; then
+    export blas_int=int64
+else
+    export blas_int=int32
+fi
+
 rm -rf ${top}/install
 if [ "${maker}" = "make" ]; then
     make distclean
@@ -27,6 +37,7 @@ fi
 if [ "${maker}" = "cmake" ]; then
     cmake -Dcolor=no \
           -DCMAKE_INSTALL_PREFIX=${top}/install \
+          -Dblas_int=${blas_int} \
           -Dgpu_backend=${gpu_backend} .. \
           || exit 12
 fi

--- a/cmake/LAPACKFinder.cmake
+++ b/cmake/LAPACKFinder.cmake
@@ -131,7 +131,7 @@ foreach (lapack_libs IN LISTS lapack_libs_list)
             # Not "quoted"; screws up OpenMP.
             ${lapack_libs} ${blaspp_libraries}
         COMPILE_DEFINITIONS
-            ${blaspp_defines}
+            ${blaspp_defs_}
         COMPILE_OUTPUT_VARIABLE
             compile_output
         RUN_OUTPUT_VARIABLE

--- a/config/config.h
+++ b/config/config.h
@@ -20,7 +20,6 @@
 
 // -----------------------------------------------------------------------------
 #if defined(BLAS_ILP64) || defined(LAPACK_ILP64)
-    // long long is >= 64 bits
     typedef int64_t blas_int;
     typedef int64_t lapack_int;
 #else

--- a/include/blas/batch_common.hh
+++ b/include/blas/batch_common.hh
@@ -129,7 +129,7 @@ void gemm_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -244,7 +244,7 @@ void trsm_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -359,7 +359,7 @@ void trmm_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -484,7 +484,7 @@ void hemm_check(
         delete[] internal_info;
 
         // throw an exception if needed
-         blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+         blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -595,7 +595,7 @@ void herk_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -725,7 +725,7 @@ void syrk_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -850,7 +850,7 @@ void her2k_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;
@@ -975,7 +975,7 @@ void syr2k_check(
         delete[] internal_info;
 
         // throw an exception if needed
-        blas_error_if_msg( info[0] != 0, "info = %lld", (long long) info[0] );
+        blas_error_if_msg( info[0] != 0, "info = %lld", llong( info[0] ) );
     }
     else {
         int64_t info_ = 0;

--- a/include/blas/config.h
+++ b/include/blas/config.h
@@ -6,14 +6,18 @@
 #ifndef BLAS_CONFIG_H
 #define BLAS_CONFIG_H
 
+#include <stdint.h>
+
 #include "blas/defines.h"
 
 #ifndef blas_int
     #if defined(BLAS_ILP64)
-        #define blas_int              long long  /* or int64_t */
+        typedef int64_t blas_int;
     #else
-        #define blas_int              int
+        typedef int blas_int;
     #endif
+    /* #define so that #ifdef works. */
+    #define blas_int blas_int
 #endif
 
 /* f2c, hence MacOS Accelerate, returns double instead of float

--- a/test/cblas_wrappers.cc
+++ b/test/cblas_wrappers.cc
@@ -48,12 +48,15 @@ cblas_rot(
     std::complex<float> *y, int incy,
     float c, std::complex<float> s )
 {
+    blas_int n_ = n;
+    blas_int incx_ = incx;
+    blas_int incy_ = incy;
     BLAS_crot(
-        &n,
+        &n_,
         (blas_complex_float*) x,
-        &incx,
+        &incx_,
         (blas_complex_float*) y,
-        &incy,
+        &incy_,
         &c,
         (blas_complex_float*) &s );
 }
@@ -65,12 +68,15 @@ cblas_rot(
     std::complex<double> *y, int incy,
     double c, std::complex<double> s )
 {
+    blas_int n_ = n;
+    blas_int incx_ = incx;
+    blas_int incy_ = incy;
     BLAS_zrot(
-        &n,
+        &n_,
         (blas_complex_double*) x,
-        &incx,
+        &incx_,
         (blas_complex_double*) y,
-        &incy,
+        &incy_,
         &c,
         (blas_complex_double*) &s );
 }

--- a/test/test.hh
+++ b/test/test.hh
@@ -232,6 +232,4 @@ void test_util  ( Params& params, bool run );
 void test_memcpy( Params& params, bool run );
 void test_memcpy_2d( Params& params, bool run );
 
-typedef long long llong;
-
 #endif        //  #ifndef TEST_HH


### PR DESCRIPTION
Fixes blas_int(value) cast when blas_int is long long. Originally:
```
src/blas_internal.hh: In function 'long long int blas::to_blas_int_(int64_t, const char*)':
./include/blas/config.h:13:39: error: expected primary-expression before 'long'
   13 |         #define blas_int              long long  /* or int64_t */
```
The cblas wrappers also had an error respecting int64:
```
test/cblas_wrappers.cc: In function 'void cblas_rot(int, std::complex<float>*, int, std::complex<float>*, int, float, std::complex<float>)':
test/cblas_wrappers.cc:52:9: error: cannot convert 'int*' to 'const blas_int*' {aka 'const long int*'}
   52 |         &n,
```
Regarding `#define` use, see https://stackoverflow.com/a/638759/1655607