### PR TITLE
Fix mistake in Queue workspace allocation

### DIFF
--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -986,7 +986,7 @@ void Queue::work_ensure_size( size_t lwork )
             device_free( work_, *this );
         }
         lwork_ = max( lwork, 3*MaxBatchChunk*sizeof(void*) );
-        work_ = device_malloc<char>( lwork, *this );
+        work_ = device_malloc<char>( lwork_, *this );
     }
 }
 


### PR DESCRIPTION
`lwork_` is sometimes set larger than the actual allocation.  Then, when `work_ensure_size` is called again with a slightly larger request, it looks like the workspace is big enough when it's actually not.