### PR TITLE
using std::foo

### DIFF
--- a/include/blas/gemv.hh
+++ b/include/blas/gemv.hh
@@ -86,7 +86,8 @@ void gemv(
     blas::scalar_type<TA, TX, TY> beta,
     TY *y, int64_t incy )
 {
-    typedef blas::scalar_type<TA, TX, TY> scalar_t;
+    using std::swap;
+    using scalar_t = blas::scalar_type<TA, TX, TY>;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]
 
@@ -118,7 +119,7 @@ void gemv(
     bool doconj = false;
     if (layout == Layout::RowMajor) {
         // A => A^T; A^T => A; A^H => A & conj
-        std::swap( m, n );
+        swap( m, n );
         if (trans == Op::NoTrans) {
             trans = Op::Trans;
         }

--- a/include/blas/hemm.hh
+++ b/include/blas/hemm.hh
@@ -93,7 +93,8 @@ void hemm(
     scalar_type<TA, TB, TC> beta,
     TC       *C, int64_t ldc )
 {
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
+    using std::swap;
+    using scalar_t = blas::scalar_type<TA, TB, TC>;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]
     #define B(i_, j_) B[ (i_) + (j_)*ldb ]
@@ -123,7 +124,7 @@ void hemm(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m, n );
+        swap( m, n );
     }
 
     // check remaining arguments

--- a/include/blas/nrm2.hh
+++ b/include/blas/nrm2.hh
@@ -36,7 +36,8 @@ nrm2(
     int64_t n,
     T const * x, int64_t incx )
 {
-    typedef real_type<T> real_t;
+    using std::sqrt;
+    using real_t = real_type<T>;
 
     // check arguments
     blas_error_if( n < 0 );      // standard BLAS returns, doesn't fail
@@ -58,7 +59,7 @@ nrm2(
             ix += incx;
         }
     }
-    return std::sqrt( result );
+    return sqrt( result );
 }
 
 }  // namespace blas

--- a/include/blas/swap.hh
+++ b/include/blas/swap.hh
@@ -42,6 +42,8 @@ void swap(
     TX *x, int64_t incx,
     TY *y, int64_t incy )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( n < 0 );      // standard BLAS returns, doesn't fail
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
@@ -50,7 +52,7 @@ void swap(
     if (incx == 1 && incy == 1) {
         // unit stride
         for (int64_t i = 0; i < n; ++i) {
-            std::swap( x[i], y[i] );
+            swap( x[i], y[i] );
         }
     }
     else {
@@ -58,7 +60,7 @@ void swap(
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);
         for (int64_t i = 0; i < n; ++i) {
-            std::swap( x[ix], y[iy] );
+            swap( x[ix], y[iy] );
             ix += incx;
             iy += incy;
         }

--- a/include/blas/symm.hh
+++ b/include/blas/symm.hh
@@ -86,7 +86,8 @@ void symm(
     scalar_type<TA, TB, TC> beta,
     TC       *C, int64_t ldc )
 {
-    typedef blas::scalar_type<TA, TB, TC> scalar_t;
+    using std::swap;
+    using scalar_t = blas::scalar_type<TA, TB>;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]
     #define B(i_, j_) B[ (i_) + (j_)*ldb ]
@@ -116,7 +117,7 @@ void symm(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m, n );
+        swap( m, n );
     }
 
     // check remaining arguments

--- a/include/blas/trmm.hh
+++ b/include/blas/trmm.hh
@@ -97,7 +97,8 @@ void trmm(
     TA const *A, int64_t lda,
     TB       *B, int64_t ldb )
 {
-    typedef blas::scalar_type<TA, TB> scalar_t;
+    using std::swap;
+    using scalar_t = blas::scalar_type<TA, TB>;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]
     #define B(i_, j_) B[ (i_) + (j_)*ldb ]
@@ -129,7 +130,7 @@ void trmm(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m, n );
+        swap( m, n );
     }
 
     // check remaining arguments

--- a/include/blas/trsm.hh
+++ b/include/blas/trsm.hh
@@ -102,7 +102,8 @@ void trsm(
     TA const *A, int64_t lda,
     TB       *B, int64_t ldb )
 {
-    typedef blas::scalar_type<TA, TB> scalar_t;
+    using std::swap;
+    using scalar_t = blas::scalar_type<TA, TB>;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]
     #define B(i_, j_) B[ (i_) + (j_)*ldb ]
@@ -134,7 +135,7 @@ void trsm(
             uplo = Uplo::Upper;
         else if (uplo == Uplo::Upper)
             uplo = Uplo::Lower;
-        std::swap( m, n );
+        swap( m, n );
     }
 
     // check remaining arguments

--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -177,13 +177,15 @@ private:
 template <typename T>
 T abs1( T x )
 {
-    return std::abs( x );
+    using std::abs;
+    return abs( x );
 }
 
 template <typename T>
 T abs1( std::complex<T> x )
 {
-    return std::abs( real(x) ) + std::abs( imag(x) );
+    using std::abs;
+    return abs( real( x ) ) + abs( imag( x ) );
 }
 
 // -----------------------------------------------------------------------------

--- a/src/device_batch_trsm.cc
+++ b/src/device_batch_trsm.cc
@@ -38,6 +38,8 @@ void trsm(
 #ifndef BLAS_HAVE_DEVICE
     throw blas::Error( "device BLAS not available", __func__ );
 #else
+    using std::swap;
+
     blas_error_if( layout != Layout::ColMajor && layout != Layout::RowMajor );
     blas_error_if( batch_size < 0 );
     blas_error_if( info.size() != 0
@@ -81,7 +83,7 @@ void trsm(
             // swap lower <=> upper, left <=> right, m <=> n
             uplo_ = ( uplo_ == blas::Uplo::Lower ? blas::Uplo::Upper : blas::Uplo::Lower );
             side_ = ( side_ == blas::Side::Left ? blas::Side::Right : blas::Side::Left );
-            std::swap( m_, n_ );
+            swap( m_, n_ );
         }
 
         // trsm needs only 2 ptr arrays (A and B). Allocate usual

--- a/src/device_hemm.cc
+++ b/src/device_hemm.cc
@@ -35,6 +35,8 @@ void hemm(
 #ifndef BLAS_HAVE_DEVICE
     throw blas::Error( "device BLAS not available", __func__ );
 #else
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -72,7 +74,7 @@ void hemm(
         // swap left <=> right, lower <=> upper, m <=> n
         side = (side == Side::Left  ? Side::Right : Side::Left);
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
 
     blas::internal_set_device( queue.device() );

--- a/src/device_symm.cc
+++ b/src/device_symm.cc
@@ -35,6 +35,8 @@ void symm(
 #ifndef BLAS_HAVE_DEVICE
     throw blas::Error( "device BLAS not available", __func__ );
 #else
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -72,7 +74,7 @@ void symm(
         // swap left <=> right, lower <=> upper, m <=> n
         side = (side == Side::Left  ? Side::Right : Side::Left);
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
 
     blas::internal_set_device( queue.device() );

--- a/src/device_trmm.cc
+++ b/src/device_trmm.cc
@@ -35,6 +35,8 @@ void trmm(
 #ifndef BLAS_HAVE_DEVICE
     throw blas::Error( "device BLAS not available", __func__ );
 #else
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -70,7 +72,7 @@ void trmm(
         // swap lower <=> upper, left <=> right, m <=> n
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         side = (side == Side::Left ? Side::Right : Side::Left);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
 
     blas::internal_set_device( queue.device() );

--- a/src/device_trsm.cc
+++ b/src/device_trsm.cc
@@ -35,6 +35,8 @@ void trsm(
 #ifndef BLAS_HAVE_DEVICE
     throw blas::Error( "device BLAS not available", __func__ );
 #else
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -70,7 +72,7 @@ void trsm(
         // swap lower <=> upper, left <=> right, m <=> n
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         side = (side == Side::Left ? Side::Right : Side::Left);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
 
     blas::internal_set_device( queue.device() );

--- a/src/gemv.cc
+++ b/src/gemv.cc
@@ -107,6 +107,8 @@ void gemv(
     scalar_t beta,
     scalar_t*       y, int64_t incy )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -158,7 +160,7 @@ void gemv(
             }
         }
         // A => A^T; A^T => A; A^H => A + conj
-        std::swap( m_, n_ );
+        swap( m_, n_ );
         trans2 = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
     }
     char trans_ = op2char( trans2 );

--- a/src/hemm.cc
+++ b/src/hemm.cc
@@ -78,6 +78,8 @@ void hemm(
     scalar_t beta,
     scalar_t*       C, int64_t ldc )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -115,7 +117,7 @@ void hemm(
         // swap left <=> right, lower <=> upper, m <=> n
         side = (side == Side::Left  ? Side::Right : Side::Left);
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
     char side_ = side2char( side );
     char uplo_ = uplo2char( uplo );

--- a/src/symm.cc
+++ b/src/symm.cc
@@ -112,6 +112,8 @@ void symm(
     scalar_t beta,
     scalar_t*       C, int64_t ldc )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -149,7 +151,7 @@ void symm(
         // swap left <=> right, lower <=> upper, m <=> n
         side = (side == Side::Left  ? Side::Right : Side::Left);
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
     char side_ = side2char( side );
     char uplo_ = uplo2char( uplo );

--- a/src/trmm.cc
+++ b/src/trmm.cc
@@ -108,6 +108,8 @@ void trmm(
     scalar_t const* A, int64_t lda,
     scalar_t*       B, int64_t ldb )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -143,7 +145,7 @@ void trmm(
         // swap lower <=> upper, left <=> right, m <=> n
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         side = (side == Side::Left ? Side::Right : Side::Left);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
     char side_  = side2char( side );
     char uplo_  = uplo2char( uplo );

--- a/src/trsm.cc
+++ b/src/trsm.cc
@@ -108,6 +108,8 @@ void trsm(
     scalar_t const* A, int64_t lda,
     scalar_t*       B, int64_t ldb )
 {
+    using std::swap;
+
     // check arguments
     blas_error_if( layout != Layout::ColMajor &&
                    layout != Layout::RowMajor );
@@ -143,7 +145,7 @@ void trsm(
         // swap lower <=> upper, left <=> right, m <=> n
         uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
         side = (side == Side::Left ? Side::Right : Side::Left);
-        std::swap( m_, n_ );
+        swap( m_, n_ );
     }
     char side_  = side2char( side );
     char uplo_  = uplo2char( uplo );

--- a/test/check_gemm.hh
+++ b/test/check_gemm.hh
@@ -34,7 +34,9 @@ void check_gemm(
     #define    C(i_, j_)    C[ (i_) + (j_)*ldc ]
     #define Cref(i_, j_) Cref[ (i_) + (j_)*ldcref ]
 
-    typedef blas::real_type<T> real_t;
+    using std::sqrt;
+    using std::abs;
+    using real_t = blas::real_type<T>;
 
     assert( m >= 0 );
     assert( n >= 0 );
@@ -52,15 +54,15 @@ void check_gemm(
     real_t work[1], Cout_norm;
     Cout_norm = lapack_lange( "f", m, n, C, ldc, work );
     error[0] = Cout_norm
-             / (sqrt(real_t(k)+2)*std::abs(alpha)*Anorm*Bnorm
-                 + 2*std::abs(beta)*Cnorm);
+             / (sqrt( real_t( k ) + 2 ) * abs( alpha ) * Anorm * Bnorm
+                 + 2 * abs( beta ) * Cnorm);
     if (verbose) {
         printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2)"
                 " * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e"
                 " + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
                 Cout_norm, llong( k ),
-                std::abs( alpha ), Anorm, Bnorm,
-                std::abs( beta ), Cnorm, error[0] );
+                abs( alpha ), Anorm, Bnorm,
+                abs( beta ), Cnorm, error[0] );
     }
 
     // complex needs extra factor; see Higham, 2002, sec. 3.6.
@@ -103,6 +105,8 @@ void check_herk(
     #define    C(i_, j_)    C[ (i_) + (j_)*ldc ]
     #define Cref(i_, j_) Cref[ (i_) + (j_)*ldcref ]
 
+    using std::sqrt;
+    using std::abs;
     typedef blas::real_type<T> real_t;
 
     assert( n >= 0 );
@@ -133,15 +137,15 @@ void check_herk(
     real_t work[1], Cout_norm;
     Cout_norm = lapack_lanhe( "f", uplo2str(uplo), n, C, ldc, work );
     error[0] = Cout_norm
-             / (sqrt(real_t(k)+2)*std::abs(alpha)*Anorm*Bnorm
-                 + 2*std::abs(beta)*Cnorm);
+             / (sqrt( real_t( k ) + 2 ) * abs( alpha ) * Anorm * Bnorm
+                 + 2 * abs( beta ) * Cnorm);
     if (verbose) {
         printf( "error: ||Cout||=%.2e / (sqrt(k=%lld + 2)"
                 " * |alpha|=%.2e * ||A||=%.2e * ||B||=%.2e"
                 " + 2 * |beta|=%.2e * ||C||=%.2e) = %.2e\n",
                 Cout_norm, llong( k ),
-                std::abs( alpha ), Anorm, Bnorm,
-                std::abs( beta ), Cnorm, error[0] );
+                abs( alpha ), Anorm, Bnorm,
+                abs( beta ), Cnorm, error[0] );
     }
 
     // complex needs extra factor; see Higham, 2002, sec. 3.6.

--- a/test/test_asum.cc
+++ b/test/test_asum.cc
@@ -15,6 +15,7 @@ template <typename T>
 void test_asum_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using std::abs;
     using real_t   = blas::real_type< T >;
 
     // get & mark input values
@@ -92,7 +93,7 @@ void test_asum_work( Params& params, bool run )
 
         // relative forward error
         // note: using sqrt(n) here gives failures
-        real_t error = std::abs( (ref - result) / (n * ref) );
+        real_t error = abs( (ref - result) / (n * ref) );
 
         // complex needs extra factor; see Higham, 2002, sec. 3.6.
         if (blas::is_complex<T>::value) {

--- a/test/test_axpy.cc
+++ b/test/test_axpy.cc
@@ -15,6 +15,7 @@ template <typename TX, typename TY>
 void test_axpy_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using std::abs;
     using std::real;
     using std::imag;
     using scalar_t = blas::scalar_type< TX, TY >;
@@ -113,8 +114,8 @@ void test_axpy_work( Params& params, bool run )
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);
         for (int64_t i = 0; i < n; ++i) {
-            y[iy] = std::abs( y[iy] - yref[iy] )
-                  / (2*(std::abs( alpha * x[ix] ) + std::abs( y0[iy] )));
+            y[iy] = abs( y[iy] - yref[iy] )
+                  / (2*(abs( alpha * x[ix] ) + abs( y0[iy] )));
             error = std::max( error, real( y[iy] ) );
             ix += incx;
             iy += incy;

--- a/test/test_axpy_device.cc
+++ b/test/test_axpy_device.cc
@@ -14,6 +14,7 @@ template <typename Tx, typename Ty>
 void test_axpy_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using std::abs;
     using std::real;
     using std::imag;
     using scalar_t = blas::scalar_type< Tx, Ty >;
@@ -130,8 +131,8 @@ void test_axpy_device_work( Params& params, bool run )
         int64_t iy = (incy > 0 ? 0 : (-n + 1)*incy);
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         for (int64_t i = 0; i < n; ++i) {
-            y[iy] = std::abs( y[iy] - yref[iy] )
-                  / (2*(std::abs( alpha * x[ix] ) + std::abs( y0[iy] )));
+            y[iy] = abs( y[iy] - yref[iy] )
+                  / (2*(abs( alpha * x[ix] ) + abs( y0[iy] )));
             ix += incx;
             iy += incy;
         }

--- a/test/test_batch_trsm.cc
+++ b/test/test_batch_trsm.cc
@@ -20,6 +20,7 @@ void test_batch_trsm_work( Params& params, bool run )
     using blas::Layout;
     using scalar_t = blas::scalar_type< TA, TB >;
     using real_t   = blas::real_type< scalar_t >;
+    using std::swap;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -47,7 +48,7 @@ void test_batch_trsm_work( Params& params, bool run )
     int64_t Bm = m_;
     int64_t Bn = n_;
     if (layout == Layout::RowMajor)
-        std::swap( Bm, Bn );
+        swap( Bm, Bn );
     int64_t lda_ = roundup( Am, align );
     int64_t ldb_ = roundup( Bm, align );
     size_t size_A = size_t(lda_)*Am;
@@ -128,7 +129,7 @@ void test_batch_trsm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             for (int64_t j = 0; j < Am; ++j) {
                 for (int64_t i = 0; i < j; ++i) {
-                    std::swap( Aarray[s][ i + j*lda_ ], Aarray[s][ j + i*lda_ ] );
+                    swap( Aarray[s][ i + j*lda_ ], Aarray[s][ j + i*lda_ ] );
                 }
             }
         }

--- a/test/test_batch_trsm_device.cc
+++ b/test/test_batch_trsm_device.cc
@@ -23,6 +23,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
     using blas::Diag;
     using scalar_t = blas::scalar_type< TA, TB >;
     using real_t   = blas::real_type< scalar_t >;
+    using std::swap;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -57,7 +58,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
     int64_t Bm    = m_;
     int64_t Bn    = n_;
     if (layout == Layout::RowMajor)
-        std::swap( Bm, Bn );
+        swap( Bm, Bn );
     int64_t lda_  = roundup( Am, align );
     int64_t ldb_  = roundup( Bm, align );
     size_t size_A = size_t(lda_)*Am;
@@ -139,7 +140,7 @@ void test_device_batch_trsm_work( Params& params, bool run )
         for (size_t s = 0; s < batch; ++s) {
             for (int64_t j = 0; j < Am; ++j) {
                 for (int64_t i = 0; i < j; ++i) {
-                    std::swap( Aarray[s][ i + j*lda_ ], Aarray[s][ j + i*lda_ ] );
+                    swap( Aarray[s][ i + j*lda_ ], Aarray[s][ j + i*lda_ ] );
                 }
             }
         }

--- a/test/test_iamax.cc
+++ b/test/test_iamax.cc
@@ -15,6 +15,7 @@ void test_iamax_work( Params& params, bool run )
 {
     using namespace testsweeper;
     using real_t   = blas::real_type< T >;
+    using std::abs;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -90,7 +91,7 @@ void test_iamax_work( Params& params, bool run )
         }
 
         // error = |ref - result|
-        real_t error = std::abs( ref - result );
+        real_t error = abs( ref - result );
         params.error() = error;
 
         // iamax must be exact!

--- a/test/test_nrm2.cc
+++ b/test/test_nrm2.cc
@@ -16,6 +16,7 @@ void test_nrm2_work( Params& params, bool run )
     using namespace testsweeper;
     typedef T scalar_t;
     using real_t   = blas::real_type< T >;
+    using std::abs;
 
     // get & mark input values
     int64_t n       = params.dim.n();
@@ -91,7 +92,7 @@ void test_nrm2_work( Params& params, bool run )
         }
 
         // relative forward error
-        real_t error = std::abs( (ref - result) / (sqrt(n+1) * ref) );
+        real_t error = abs( (ref - result) / (sqrt(n+1) * ref) );
 
         // complex needs extra factor; see Higham, 2002, sec. 3.6.
         if (blas::is_complex<scalar_t>::value) {

--- a/test/test_nrm2_device.cc
+++ b/test/test_nrm2_device.cc
@@ -16,6 +16,7 @@ void test_nrm2_device_work( Params& params, bool run )
     using namespace testsweeper;
     using scalar_t = blas::scalar_type<Tx>;
     using real_t   = blas::real_type<scalar_t>;
+    using std::abs;
 
     // get & mark input values
     char mode       = params.pointer_mode();
@@ -128,7 +129,7 @@ void test_nrm2_device_work( Params& params, bool run )
         }
 
         // relative forward error:
-        real_t error = std::abs( (result_cblas - result_host)
+        real_t error = abs( (result_cblas - result_host)
                            / (sqrt(n+1) * result_cblas) );
         params.error() = error;
 

--- a/test/test_rotg.cc
+++ b/test/test_rotg.cc
@@ -13,6 +13,7 @@ template <typename T>
 void test_rotg_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using std::abs;
     using std::real;
     using std::imag;
     using real_t   = blas::real_type< T >;
@@ -103,10 +104,10 @@ void test_rotg_work( Params& params, bool run )
         int64_t is = cblas_iamax( n, &sref[0], 1 );
 
         real_t error = blas::max(
-            std::abs( aref[ ia ] ),
-            std::abs( bref[ ib ] ),
-            std::abs( cref[ ic ] ),
-            std::abs( sref[ is ] )
+            abs( aref[ ia ] ),
+            abs( bref[ ib ] ),
+            abs( cref[ ic ] ),
+            abs( sref[ is ] )
         );
 
         // error is normally 0, but allow for some rounding just in case.

--- a/test/test_rotmg.cc
+++ b/test/test_rotmg.cc
@@ -13,6 +13,7 @@ template <typename T>
 void test_rotmg_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using std::abs;
     using std::real;
     using std::imag;
     using real_t   = blas::real_type< T >;
@@ -83,10 +84,10 @@ void test_rotmg_work( Params& params, bool run )
         int64_t ips = cblas_iamax( 5*n, &ps_ref[0], 1 );
 
         real_t error = blas::max(
-            std::abs( d1_ref[ id1 ] ),
-            std::abs( d2_ref[ id2 ] ),
-            std::abs( x1_ref[ ix1 ] ),
-            std::abs( ps_ref[ ips ] )
+            abs( d1_ref[ id1 ] ),
+            abs( d2_ref[ id2 ] ),
+            abs( x1_ref[ ix1 ] ),
+            abs( ps_ref[ ips ] )
         );
 
         // error is normally 0, but allow for some rounding just in case.

--- a/test/test_scal.cc
+++ b/test/test_scal.cc
@@ -14,6 +14,8 @@ template <typename T>
 void test_scal_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using blas::max;
+    using std::abs;
     using std::real;
     using std::imag;
     using real_t = blas::real_type< T >;
@@ -101,7 +103,7 @@ void test_scal_work( Params& params, bool run )
         real_t error = 0;
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         for (int64_t i = 0; i < n; ++i) {
-            error = std::max( error, std::abs( (xref[ix] - x[ix]) / xref[ix] ));
+            error = max( error, abs( (xref[ix] - x[ix]) / xref[ix] ));
             ix += incx;
         }
         params.error() = error;

--- a/test/test_scal_device.cc
+++ b/test/test_scal_device.cc
@@ -14,6 +14,8 @@ template <typename T>
 void test_scal_device_work( Params& params, bool run )
 {
     using namespace testsweeper;
+    using blas::max;
+    using std::abs;
     using std::real;
     using std::imag;
     using real_t = blas::real_type< T >;
@@ -120,7 +122,7 @@ void test_scal_device_work( Params& params, bool run )
         real_t error = 0;
         int64_t ix = (incx > 0 ? 0 : (-n + 1)*incx);
         for (int64_t i = 0; i < n; ++i) {
-            error = std::max( error, std::abs( (xref[ix] - x[ix]) / xref[ix] ));
+            error = max( error, abs( (xref[ix] - x[ix]) / xref[ix] ));
             ix += incx;
         }
         params.error() = error;

--- a/test/test_trsm.cc
+++ b/test/test_trsm.cc
@@ -22,6 +22,7 @@ void test_trsm_work( Params& params, bool run )
     using blas::Diag;
     using scalar_t = blas::scalar_type< TA, TB >;
     using real_t   = blas::real_type< scalar_t >;
+    using std::swap;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -49,7 +50,7 @@ void test_trsm_work( Params& params, bool run )
     int64_t Bm = m;
     int64_t Bn = n;
     if (layout == Layout::RowMajor)
-        std::swap( Bm, Bn );
+        swap( Bm, Bn );
     int64_t lda = roundup( Am, align );
     int64_t ldb = roundup( Bm, align );
     size_t size_A = size_t(lda)*Am;
@@ -96,7 +97,7 @@ void test_trsm_work( Params& params, bool run )
     if (layout == Layout::RowMajor) {
         for (int64_t j = 0; j < Am; ++j) {
             for (int64_t i = 0; i < j; ++i) {
-                std::swap( A[ i + j*lda ], A[ j + i*lda ] );
+                swap( A[ i + j*lda ], A[ j + i*lda ] );
             }
         }
     }

--- a/test/test_trsm_device.cc
+++ b/test/test_trsm_device.cc
@@ -22,6 +22,7 @@ void test_trsm_device_work( Params& params, bool run )
     using blas::Diag;
     using scalar_t = blas::scalar_type< TA, TB >;
     using real_t   = blas::real_type< scalar_t >;
+    using std::swap;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -55,7 +56,7 @@ void test_trsm_device_work( Params& params, bool run )
     int64_t Bm = m;
     int64_t Bn = n;
     if (layout == Layout::RowMajor)
-        std::swap( Bm, Bn );
+        swap( Bm, Bn );
     int64_t lda = roundup( Am, align );
     int64_t ldb = roundup( Bm, align );
     size_t size_A = size_t(lda)*Am;
@@ -110,7 +111,7 @@ void test_trsm_device_work( Params& params, bool run )
     if (layout == Layout::RowMajor) {
         for (int64_t j = 0; j < Am; ++j) {
             for (int64_t i = 0; i < j; ++i) {
-                std::swap( A[ i + j*lda ], A[ j + i*lda ] );
+                swap( A[ i + j*lda ], A[ j + i*lda ] );
             }
         }
     }

--- a/test/test_trsv.cc
+++ b/test/test_trsv.cc
@@ -23,6 +23,7 @@ void test_trsv_work( Params& params, bool run )
     using blas::Diag;
     using scalar_t = blas::scalar_type< TA, TX >;
     using real_t   = blas::real_type< scalar_t >;
+    using std::swap;
 
     // get & mark input values
     blas::Layout layout = params.layout();
@@ -95,7 +96,7 @@ void test_trsv_work( Params& params, bool run )
     if (layout == Layout::RowMajor) {
         for (int64_t j = 0; j < n; ++j) {
             for (int64_t i = 0; i < j; ++i) {
-                std::swap( A[ i + j*lda ], A[ j + i*lda ] );
+                swap( A[ i + j*lda ], A[ j + i*lda ] );
             }
         }
     }


### PR DESCRIPTION
Do
```
    using std::sqrt;
    y = sqrt( x );
```
instead of
```
    y = std::sqrt( x );
```
and similar functions, when x is a user-defined type (scalar_t). Resolves #43.