### PR TITLE
rocm: support rocBLAS 3.0 trmm with 3 matrices A, B, C

### DIFF
--- a/src/rocblas_wrappers.cc
+++ b/src/rocblas_wrappers.cc
@@ -3,9 +3,14 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
+#define ROCBLAS_V3
+
 #include "device_internal.hh"
 
 #ifdef BLAS_HAVE_ROCBLAS
+
+// ROCm doesn't define ROCBLAS_VERSION as one variable (as of 5.7.1).
+#define rocblas_version ROCBLAS_VERSION_MAJOR*10000000 + ROCBLAS_VERSION_MINOR*100000 + ROCBLAS_VERSION_PATCH
 
 #ifdef __HIP_PLATFORM_NVCC__
     #warning Compiling with rocBLAS on NVCC mode... This is an odd configuration. (Consider using NVCC only)
@@ -667,6 +672,9 @@ void trmm(
             m, n,
             &alpha,
             dA, ldda,
+            #if rocblas_version >= 30000000  // 3.0.0 (ROCm 5.6.0)
+            dB, lddb,
+            #endif
             dB, lddb ) );
 }
 
@@ -686,6 +694,9 @@ void trmm(
             m, n,
             &alpha,
             dA, ldda,
+            #if rocblas_version >= 30000000  // 3.0.0 (ROCm 5.6.0)
+            dB, lddb,
+            #endif
             dB, lddb ) );
 }
 
@@ -705,6 +716,9 @@ void trmm(
             m, n,
             (rocblas_float_complex*) &alpha,
             (rocblas_float_complex*) dA, ldda,
+            #if rocblas_version >= 30000000  // 3.0.0 (ROCm 5.6.0)
+            (rocblas_float_complex*) dB, lddb,
+            #endif
             (rocblas_float_complex*) dB, lddb ) );
 }
 
@@ -724,6 +738,9 @@ void trmm(
             m, n,
             (rocblas_double_complex*) &alpha,
             (rocblas_double_complex*) dA, ldda,
+            #if rocblas_version >= 30000000  // 3.0.0 (ROCm 5.6.0)
+            (rocblas_double_complex*) dB, lddb,
+            #endif
             (rocblas_double_complex*) dB, lddb ) );
 }
 

--- a/test/test.cc
+++ b/test/test.cc
@@ -11,6 +11,20 @@
 
 #include "test.hh"
 
+// Headers for versions.
+#ifdef BLAS_HAVE_MKL
+    #include <mkl.h>
+#endif
+#ifdef BLAS_HAVE_OPENBLAS
+    #include <cblas.h>
+#endif
+#ifdef BLAS_HAVE_CUBLAS
+    #include <cuda_runtime.h>
+#endif
+#ifdef BLAS_HAVE_ROCBLAS
+    #include <rocm-core/rocm_version.h>
+#endif
+
 // -----------------------------------------------------------------------------
 using testsweeper::ParamType;
 using testsweeper::DataType;
@@ -296,9 +310,47 @@ int main( int argc, char** argv )
     int status = 0;
     try {
         int version = blas::blaspp_version();
-        printf( "BLAS++ version %d.%02d.%02d, id %s\n",
+        printf( "BLAS++ version %d.%02d.%02d, id %s",
                 version / 10000, (version % 10000) / 100, version % 100,
                 blas::blaspp_id() );
+
+        // CPU BLAS
+        // todo: Accelerate, IBM ESSL, Cray LibSci, BLIS, etc. version.
+        #ifdef BLAS_HAVE_ACCELERATE
+            printf( ", Apple Accelerate" );
+        #endif
+        #ifdef BLAS_HAVE_ESSL
+            printf( ", IBM ESSL" );
+        #endif
+        #ifdef BLAS_HAVE_MKL
+            MKLVersion mkl_version;
+            mkl_get_version( &mkl_version );
+            printf( ", Intel MKL %d.%d.%d",
+                    mkl_version.MajorVersion,
+                    mkl_version.MinorVersion,
+                    mkl_version.UpdateVersion );
+        #endif
+        #ifdef BLAS_HAVE_OPENBLAS
+            printf( ", %s", OPENBLAS_VERSION );
+        #endif
+
+        // GPU BLAS
+        #ifdef BLAS_HAVE_CUBLAS
+            printf( ", CUDA %d.%d.%d",
+                    CUDART_VERSION / 1000,
+                    (CUDART_VERSION % 1000) / 100,
+                    CUDART_VERSION % 10 );
+        #endif
+        #ifdef BLAS_HAVE_ROCBLAS
+            printf( ", ROCm %d.%d.%d",
+                    ROCM_VERSION_MAJOR,
+                    ROCM_VERSION_MINOR,
+                    ROCM_VERSION_PATCH );
+        #endif
+        #ifdef BLAS_HAVE_SYCL
+            printf( ", SYCL" );
+        #endif
+        printf( "\n" );
 
         // print input so running `test [input] > out.txt` documents input
         printf( "input: %s", argv[0] );


### PR DESCRIPTION
rocBLAS 3.0 in ROCm 5.6.0 introduced a 3 matrix trmm, with separate B and C matrices that can be aliased. See
https://rocblas.readthedocs.io/en/master/API_Reference_Guide.html#rocblas-xtrmm-batched-strided-batched
This updates BLAS++ to call the new interface when available.

Also print the CPU and GPU BLAS version, where known. Tested on various systems:
```
pangolin blaspp> ./test/tester
BLAS++ version 2023.11.05, id 92ad3b4f,  OpenBLAS 0.3.21 

pangolin blaspp> ./test/tester
BLAS++ version 2023.11.05, id 92ad3b4f, Apple Accelerate

methane blaspp> ./test/tester 
BLAS++ version 2023.11.05, id 92ad3b4f, Intel MKL 2023.0.2, CUDA 11.0.0

dopamine blaspp> ./test/tester
BLAS++ version 2023.11.05, id 92ad3b4f, Intel MKL 2023.0.2, ROCm 5.7.1
```