### PR TITLE
 Add soversion to shared library

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,14 +13,14 @@
 #   AR, RANLIB      -- Archiver, ranlib updates library TOC
 #   prefix          -- where to install BLAS++
 
-ifeq ($(MAKECMDGOALS),config)
+ifeq (${MAKECMDGOALS},config)
     # For `make config`, don't include make.inc with previous config;
     # force re-creating make.inc.
     .PHONY: config
     config: make.inc
 
     make.inc: force
-else ifneq ($(findstring clean,$(MAKECMDGOALS)),clean)
+else ifneq ($(findstring clean,${MAKECMDGOALS}),clean)
     # For `make clean` or `make distclean`, don't include make.inc,
     # which could generate it. Otherwise, include make.inc.
     include make.inc
@@ -40,14 +40,14 @@ prefix   ?= /opt/slate
 abs_prefix := ${abspath ${prefix}}
 
 # Default LD=ld won't work; use CXX. Can override in make.inc or environment.
-ifeq ($(origin LD),default)
-    LD = $(CXX)
+ifeq (${origin LD},default)
+    LD = ${CXX}
 endif
 
 # auto-detect OS
 # $OSTYPE may not be exported from the shell, so echo it
-ostype := $(shell echo $${OSTYPE})
-ifneq ($(findstring darwin, $(ostype)),)
+ostype := ${shell echo $${OSTYPE}}
+ifneq ($(findstring darwin, ${ostype}),)
     # MacOS is darwin
     macos = 1
 endif
@@ -62,7 +62,7 @@ endif
 
 #-------------------------------------------------------------------------------
 # if shared
-ifneq ($(static),1)
+ifneq (${static},1)
     CXXFLAGS += -fPIC
     LDFLAGS  += -fPIC
     lib_ext = so
@@ -72,8 +72,8 @@ endif
 
 #-------------------------------------------------------------------------------
 # MacOS needs shared library's path set
-ifeq ($(macos),1)
-    install_name = -install_name @rpath/$(notdir $@)
+ifeq (${macos},1)
+    install_name = -install_name @rpath/${notdir $@}
 else
     install_name =
 endif
@@ -81,50 +81,50 @@ endif
 #-------------------------------------------------------------------------------
 # Files
 
-lib_src  = $(wildcard src/*.cc)
-lib_obj  = $(addsuffix .o, $(basename $(lib_src)))
-dep     += $(addsuffix .d, $(basename $(lib_src)))
+lib_src  = ${wildcard src/*.cc}
+lib_obj  = ${addsuffix .o, ${basename ${lib_src}}}
+dep     += ${addsuffix .d, ${basename ${lib_src}}}
 
-tester_src = $(wildcard test/*.cc)
-tester_obj = $(addsuffix .o, $(basename $(tester_src)))
-dep       += $(addsuffix .d, $(basename $(tester_src)))
+tester_src = ${wildcard test/*.cc}
+tester_obj = ${addsuffix .o, ${basename ${tester_src}}}
+dep       += ${addsuffix .d, ${basename ${tester_src}}}
 
 tester     = test/tester
 
 #-------------------------------------------------------------------------------
 # TestSweeper
 
-testsweeper_dir = $(wildcard ../testsweeper)
-ifeq ($(testsweeper_dir),)
-    testsweeper_dir = $(wildcard ./testsweeper)
+testsweeper_dir = ${wildcard ../testsweeper}
+ifeq (${testsweeper_dir},)
+    testsweeper_dir = ${wildcard ./testsweeper}
 endif
-ifeq ($(testsweeper_dir),)
-    $(tester_obj):
+ifeq (${testsweeper_dir},)
+    ${tester_obj}:
 		$(error Tester requires TestSweeper, which was not found. Run 'make config' \
 		        or download manually from https://github.com/icl-utk-edu/testsweeper)
 endif
 
-testsweeper_src = $(wildcard $(testsweeper_dir)/testsweeper.cc $(testsweeper_dir)/testsweeper.hh)
+testsweeper_src = ${wildcard ${testsweeper_dir}/testsweeper.cc ${testsweeper_dir}/testsweeper.hh}
 
-testsweeper = $(testsweeper_dir)/libtestsweeper.$(lib_ext)
+testsweeper = ${testsweeper_dir}/libtestsweeper.${lib_ext}
 
-testsweeper: $(testsweeper)
+testsweeper: ${testsweeper}
 
 #-------------------------------------------------------------------------------
 # Get Mercurial id, and make version.o depend on it via .id file.
 
-ifneq ($(wildcard .git),)
-    id := $(shell git rev-parse --short HEAD)
-    src/version.o: CXXFLAGS += -DBLASPP_ID='"$(id)"'
+ifneq (${wildcard .git},)
+    id := ${shell git rev-parse --short HEAD}
+    src/version.o: CXXFLAGS += -DBLASPP_ID='"${id}"'
 endif
 
-last_id := $(shell [ -e .id ] && cat .id || echo 'NA')
-ifneq ($(id),$(last_id))
+last_id := ${shell [ -e .id ] && cat .id || echo 'NA'}
+ifneq (${id},${last_id})
     .id: force
 endif
 
 .id:
-	echo $(id) > .id
+	echo ${id} > .id
 
 src/version.o: .id
 
@@ -133,10 +133,10 @@ src/version.o: .id
 CXXFLAGS += -I./include
 
 # additional flags and libraries for testers
-$(tester_obj): CXXFLAGS += -I$(testsweeper_dir)
+${tester_obj}: CXXFLAGS += -I${testsweeper_dir}
 
-TEST_LDFLAGS += -L./lib -Wl,-rpath,$(abspath ./lib)
-TEST_LDFLAGS += -L$(testsweeper_dir) -Wl,-rpath,$(abspath $(testsweeper_dir))
+TEST_LDFLAGS += -L./lib -Wl,-rpath,${abspath ./lib}
+TEST_LDFLAGS += -L${testsweeper_dir} -Wl,-rpath,${abspath ${testsweeper_dir}}
 TEST_LIBS    += -lblaspp -ltestsweeper
 
 #-------------------------------------------------------------------------------
@@ -150,68 +150,68 @@ all: lib tester hooks
 
 pkg = lib/pkgconfig/blaspp.pc
 
-install: lib $(pkg)
-	mkdir -p $(DESTDIR)$(abs_prefix)/include/blas
-	mkdir -p $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)
-	mkdir -p $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)/pkgconfig
-	cp include/*.hh $(DESTDIR)$(abs_prefix)/include/
-	cp include/blas/*.h  $(DESTDIR)$(abs_prefix)/include/blas/
-	cp include/blas/*.hh $(DESTDIR)$(abs_prefix)/include/blas/
-	cp -R lib/lib* $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)/
-	cp $(pkg) $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)/pkgconfig/
+install: lib ${pkg}
+	mkdir -p ${DESTDIR}${abs_prefix}/include/blas
+	mkdir -p ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}
+	mkdir -p ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}/pkgconfig
+	cp include/*.hh ${DESTDIR}${abs_prefix}/include/
+	cp include/blas/*.h  ${DESTDIR}${abs_prefix}/include/blas/
+	cp include/blas/*.hh ${DESTDIR}${abs_prefix}/include/blas/
+	cp -R lib/lib* ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}/
+	cp ${pkg} ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}/pkgconfig/
 
 uninstall:
-	$(RM)    $(DESTDIR)$(abs_prefix)/include/blas.hh
-	$(RM) -r $(DESTDIR)$(abs_prefix)/include/blas
-	$(RM) $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)/libblaspp.*
-	$(RM) $(DESTDIR)$(abs_prefix)/lib$(LIB_SUFFIX)/pkgconfig/blaspp.pc
+	${RM}    ${DESTDIR}${abs_prefix}/include/blas.hh
+	${RM} -r ${DESTDIR}${abs_prefix}/include/blas
+	${RM} ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}/libblaspp.*
+	${RM} ${DESTDIR}${abs_prefix}/lib${LIB_SUFFIX}/pkgconfig/blaspp.pc
 
 #-------------------------------------------------------------------------------
 # if re-configured, recompile everything
-$(lib_obj) $(tester_obj): make.inc
+${lib_obj} ${tester_obj}: make.inc
 
 #-------------------------------------------------------------------------------
 # BLAS++ library
 lib_a  = lib/libblaspp.a
 lib_so = lib/libblaspp.so
-lib    = lib/libblaspp.$(lib_ext)
+lib    = lib/libblaspp.${lib_ext}
 
-$(lib_so): $(lib_obj)
+${lib_so}: ${lib_obj}
 	mkdir -p lib
-	$(LD) $(LDFLAGS) -shared $(install_name) $(lib_obj) $(LIBS) -o $@
+	${LD} ${LDFLAGS} -shared ${install_name} ${lib_obj} ${LIBS} -o $@
 
-$(lib_a): $(lib_obj)
+${lib_a}: ${lib_obj}
 	mkdir -p lib
-	$(RM) $@
-	$(AR) cr $@ $(lib_obj)
-	$(RANLIB) $@
+	${RM} $@
+	${AR} cr $@ ${lib_obj}
+	${RANLIB} $@
 
 # sub-directory rules
-lib src: $(lib)
+lib src: ${lib}
 
 lib/clean src/clean:
-	$(RM) lib/*.a lib/*.so src/*.o
+	${RM} lib/*.a lib/*.so src/*.o
 
 #-------------------------------------------------------------------------------
 # TestSweeper library
-ifneq ($(testsweeper_dir),)
-    $(testsweeper): $(testsweeper_src)
-		cd $(testsweeper_dir) && $(MAKE) lib CXX=$(CXX)
+ifneq (${testsweeper_dir},)
+    ${testsweeper}: ${testsweeper_src}
+		cd ${testsweeper_dir} && ${MAKE} lib CXX=${CXX}
 endif
 
 #-------------------------------------------------------------------------------
 # tester
-$(tester): $(tester_obj) $(lib) $(testsweeper)
-	$(LD) $(TEST_LDFLAGS) $(LDFLAGS) $(tester_obj) \
-		$(TEST_LIBS) $(LIBS) -o $@
+${tester}: ${tester_obj} ${lib} ${testsweeper}
+	${LD} ${TEST_LDFLAGS} ${LDFLAGS} ${tester_obj} \
+		${TEST_LIBS} ${LIBS} -o $@
 
 # sub-directory rules
 # Note 'test' is sub-directory rule; 'tester' is CMake-compatible rule.
-test: $(tester)
-tester: $(tester)
+test: ${tester}
+tester: ${tester}
 
 test/clean:
-	$(RM) $(tester) test/*.o
+	${RM} ${tester} test/*.o
 
 test/check: check
 
@@ -221,13 +221,13 @@ check: tester
 #-------------------------------------------------------------------------------
 # headers
 # precompile headers to verify self-sufficiency
-headers     = $(wildcard include/blas.hh include/blas/*.h include/blas/*.hh test/*.hh)
-headers_gch = $(addsuffix .gch, $(basename $(headers)))
+headers     = ${wildcard include/blas.hh include/blas/*.h include/blas/*.hh test/*.hh}
+headers_gch = ${addsuffix .gch, ${basename ${headers}}}
 
-headers: $(headers_gch)
+headers: ${headers_gch}
 
 headers/clean:
-	$(RM) $(headers_gch)
+	${RM} ${headers_gch}
 
 # sub-directory rules
 include: headers
@@ -237,12 +237,12 @@ include/clean: headers/clean
 #-------------------------------------------------------------------------------
 # pkgconfig
 # Keep -std=c++11 in CXXFLAGS. Keep -fopenmp in LDFLAGS.
-CXXFLAGS_clean = $(filter-out -O% -W% -pedantic -D% -I./include -MMD -fPIC -fopenmp, $(CXXFLAGS))
-CPPFLAGS_clean = $(filter-out -O% -W% -pedantic -D% -I./include -MMD -fPIC -fopenmp, $(CPPFLAGS))
-LDFLAGS_clean  = $(filter-out -fPIC, $(LDFLAGS))
+CXXFLAGS_clean = ${filter-out -O% -W% -pedantic -D% -I./include -MMD -fPIC -fopenmp, ${CXXFLAGS}}
+CPPFLAGS_clean = ${filter-out -O% -W% -pedantic -D% -I./include -MMD -fPIC -fopenmp, ${CPPFLAGS}}
+LDFLAGS_clean  = ${filter-out -fPIC, ${LDFLAGS}}
 
-.PHONY: $(pkg)
-$(pkg):
+.PHONY: ${pkg}
+${pkg}:
 	perl -pe "s'#VERSION'2023.11.05'; \
 	          s'#PREFIX'${abs_prefix}'; \
 	          s'#CXX\b'${CXX}'; \
@@ -263,7 +263,7 @@ doc_files = \
 	README.md \
 	INSTALL.md \
 
-docs/html/index.html: $(headers) $(lib_src) $(tester_src) $(doc_files)
+docs/html/index.html: ${headers} ${lib_src} ${tester_src} ${doc_files}
 	doxygen docs/doxygen/doxyfile.conf
 	@echo ========================================
 	cat docs/doxygen/errors.txt
@@ -278,10 +278,10 @@ test/docs: docs
 #-------------------------------------------------------------------------------
 # general rules
 clean: lib/clean test/clean headers/clean
-	$(RM) $(dep)
+	${RM} ${dep}
 
 distclean: clean
-	$(RM) make.inc include/blas/defines.h
+	${RM} make.inc include/blas/defines.h
 
 # Install git hooks
 hooks = .git/hooks/pre-commit
@@ -295,62 +295,62 @@ hooks: ${hooks}
 	fi
 
 %.o: %.cc
-	$(CXX) $(CXXFLAGS) -c $< -o $@
+	${CXX} ${CXXFLAGS} -c $< -o $@
 
 # preprocess source
 %.i: %.cc
-	$(CXX) $(CXXFLAGS) -I$(testsweeper_dir) -E $< -o $@
+	${CXX} ${CXXFLAGS} -I${testsweeper_dir} -E $< -o $@
 
 # preprocess source
 %.i: %.h
-	$(CXX) $(CXXFLAGS) -I$(testsweeper_dir) -E $< -o $@
+	${CXX} ${CXXFLAGS} -I${testsweeper_dir} -E $< -o $@
 
 # preprocess source
 %.i: %.hh
-	$(CXX) $(CXXFLAGS) -I$(testsweeper_dir) -E $< -o $@
+	${CXX} ${CXXFLAGS} -I${testsweeper_dir} -E $< -o $@
 
 # precompile header to check for errors
 %.gch: %.h
-	$(CXX) $(CXXFLAGS) -I$(testsweeper_dir) -c $< -o $@
+	${CXX} ${CXXFLAGS} -I${testsweeper_dir} -c $< -o $@
 
 %.gch: %.hh
-	$(CXX) $(CXXFLAGS) -I$(testsweeper_dir) -c $< -o $@
+	${CXX} ${CXXFLAGS} -I${testsweeper_dir} -c $< -o $@
 
--include $(dep)
+-include ${dep}
 
 #-------------------------------------------------------------------------------
 # debugging
 echo:
-	@echo "static        = '$(static)'"
-	@echo "id            = '$(id)'"
-	@echo "last_id       = '$(last_id)'"
+	@echo "static        = '${static}'"
+	@echo "id            = '${id}'"
+	@echo "last_id       = '${last_id}'"
 	@echo
-	@echo "lib_a         = $(lib_a)"
-	@echo "lib_so        = $(lib_so)"
-	@echo "lib           = $(lib)"
+	@echo "lib_a         = ${lib_a}"
+	@echo "lib_so        = ${lib_so}"
+	@echo "lib           = ${lib}"
 	@echo
-	@echo "lib_src       = $(lib_src)"
+	@echo "lib_src       = ${lib_src}"
 	@echo
-	@echo "lib_obj       = $(lib_obj)"
+	@echo "lib_obj       = ${lib_obj}"
 	@echo
-	@echo "tester_src    = $(tester_src)"
+	@echo "tester_src    = ${tester_src}"
 	@echo
-	@echo "tester_obj    = $(tester_obj)"
+	@echo "tester_obj    = ${tester_obj}"
 	@echo
-	@echo "tester        = $(tester)"
+	@echo "tester        = ${tester}"
 	@echo
-	@echo "dep           = $(dep)"
+	@echo "dep           = ${dep}"
 	@echo
-	@echo "testsweeper_dir   = $(testsweeper_dir)"
-	@echo "testsweeper_src   = $(testsweeper_src)"
-	@echo "testsweeper       = $(testsweeper)"
+	@echo "testsweeper_dir   = ${testsweeper_dir}"
+	@echo "testsweeper_src   = ${testsweeper_src}"
+	@echo "testsweeper       = ${testsweeper}"
 	@echo
-	@echo "CXX           = $(CXX)"
-	@echo "CXXFLAGS      = $(CXXFLAGS)"
+	@echo "CXX           = ${CXX}"
+	@echo "CXXFLAGS      = ${CXXFLAGS}"
 	@echo
-	@echo "LD            = $(LD)"
-	@echo "LDFLAGS       = $(LDFLAGS)"
-	@echo "LIBS          = $(LIBS)"
+	@echo "LD            = ${LD}"
+	@echo "LDFLAGS       = ${LDFLAGS}"
+	@echo "LIBS          = ${LIBS}"
 	@echo
-	@echo "TEST_LDFLAGS  = $(TEST_LDFLAGS)"
-	@echo "TEST_LIBS     = $(TEST_LIBS)"
+	@echo "TEST_LDFLAGS  = ${TEST_LDFLAGS}"
+	@echo "TEST_LIBS     = ${TEST_LIBS}"

--- a/src/device_utils.cc
+++ b/src/device_utils.cc
@@ -10,28 +10,6 @@
 namespace blas {
 
 // -----------------------------------------------------------------------------
-/// @deprecated
-/// Set current GPU device.
-/// (CUDA, ROCm only; doesn't work with SYCL.)
-void set_device( int device )
-{
-    #ifdef BLAS_HAVE_CUBLAS
-        blas_dev_call(
-            cudaSetDevice( device ) );
-
-    #elif defined(BLAS_HAVE_ROCBLAS)
-        blas_dev_call(
-            hipSetDevice( device ) );
-
-    #elif defined(BLAS_HAVE_SYCL)
-        throw blas::Error( "unsupported function for sycl backend", __func__ );
-
-    #else
-        throw blas::Error( "device BLAS not available", __func__ );
-    #endif
-}
-
-// -----------------------------------------------------------------------------
 /// Set the current GPU device as needed by the accelerator/gpu.
 /// (CUDA, ROCm only; no-op for SYCL.)
 void internal_set_device( int device )
@@ -49,32 +27,6 @@ void internal_set_device( int device )
 
     #else
         throw blas::Error( "unknown accelerator/gpu", __func__ );
-    #endif
-}
-
-// -----------------------------------------------------------------------------
-/// @deprecated
-/// Get current GPU device.
-/// (CUDA, ROCm only; doesn't work with SYCL.)
-void get_device( int *device )
-{
-    #ifdef BLAS_HAVE_CUBLAS
-        device_blas_int dev = -1;
-        blas_dev_call(
-            cudaGetDevice(&dev) );
-        (*device) = dev;
-
-    #elif defined(BLAS_HAVE_ROCBLAS)
-        device_blas_int dev = -1;
-        blas_dev_call(
-            hipGetDevice(&dev) );
-        (*device) = dev;
-
-    #elif defined(BLAS_HAVE_SYCL)
-        throw blas::Error( "unsupported function for sycl backend", __func__ );
-
-    #else
-        throw blas::Error( "device BLAS not available", __func__ );
     #endif
 }
 
@@ -102,30 +54,6 @@ int get_device_count()
 }
 
 // -----------------------------------------------------------------------------
-/// @deprecated: use device_free( ptr, queue ).
-/// Free a device memory space on the current device,
-/// allocated with device_malloc.
-/// (CUDA, ROCm only; doesn't work with SYCL.)
-void device_free( void* ptr )
-{
-    #ifdef BLAS_HAVE_CUBLAS
-        blas_dev_call(
-            cudaFree( ptr ) );
-
-    #elif defined(BLAS_HAVE_ROCBLAS)
-        blas_dev_call(
-            hipFree( ptr ) );
-
-    #elif defined(BLAS_HAVE_SYCL)
-        /// SYCL requires a device/queue to free.
-        throw blas::Error( "unsupported function for sycl backend", __func__ );
-
-    #else
-        throw blas::Error( "device BLAS not available", __func__ );
-    #endif
-}
-
-// -----------------------------------------------------------------------------
 /// Free a device memory space, allocated with device_malloc,
 /// on the queue's device.
 void device_free( void* ptr, blas::Queue &queue )
@@ -143,28 +71,6 @@ void device_free( void* ptr, blas::Queue &queue )
     #elif defined(BLAS_HAVE_SYCL)
         blas_dev_call(
             sycl::free( ptr, queue.stream() ) );
-    #endif
-}
-
-// -----------------------------------------------------------------------------
-/// @deprecated: use host_free_pinned( ptr, queue ).
-/// Free a pinned host memory space, allocated with host_malloc_pinned.
-/// (CUDA, ROCm only; doesn't work with SYCL.)
-void host_free_pinned( void* ptr )
-{
-    #ifdef BLAS_HAVE_CUBLAS
-        blas_dev_call(
-            cudaFreeHost( ptr ) );
-
-    #elif defined(BLAS_HAVE_ROCBLAS)
-        blas_dev_call(
-            hipHostFree( ptr ) );
-
-    #elif defined(BLAS_HAVE_SYCL)
-        throw blas::Error( "unsupported function for sycl backend", __func__ );
-
-    #else
-        throw blas::Error( "device BLAS not available", __func__ );
     #endif
 }
 


### PR DESCRIPTION
See description in https://github.com/icl-utk-edu/testsweeper/pull/23 and https://github.com/icl-utk-edu/testsweeper/pull/25.

Remove deprecated functions (before initial soversion). Deprecate MemcpyKind and related functions.