### PR TITLE
make: update ${ }

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -20,7 +20,7 @@ ifeq (${MAKECMDGOALS},config)
     config: make.inc
 
     make.inc: force
-else ifneq ($(findstring clean,${MAKECMDGOALS}),clean)
+else ifneq (clean,${findstring clean,${MAKECMDGOALS}})
     # For `make clean` or `make distclean`, don't include make.inc,
     # which could generate it. Otherwise, include make.inc.
     include make.inc
@@ -67,7 +67,7 @@ ldflags_shared = -shared
 # auto-detect OS
 # $OSTYPE may not be exported from the shell, so echo it
 ostype := ${shell echo $${OSTYPE}}
-ifneq ($(findstring darwin, ${ostype}),)
+ifneq (,${findstring darwin, ${ostype}})
     # MacOS is darwin
     macos = 1
     # MacOS needs shared library's path set, and shared library version.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -373,19 +373,29 @@ hooks: ${hooks}
 #-------------------------------------------------------------------------------
 # debugging
 echo:
-	@echo "ostype        = '${ostype}'"
+	@echo "---------- Options"
 	@echo "static        = '${static}'"
+	@echo "prefix        = '${prefix}'"
+	@echo "abs_prefix    = '${abs_prefix}'"
+	@echo "papi          = '${papi}'"
+	@echo
+	@echo "---------- Internal variables"
+	@echo "ostype        = '${ostype}'"
+	@echo "macos         = '${macos}'"
 	@echo "id            = '${id}'"
 	@echo "last_id       = '${last_id}'"
 	@echo "abi_version   = '${abi_version}'"
 	@echo "soversion     = '${soversion}'"
 	@echo
+	@echo "---------- Libraries"
 	@echo "lib_name      = ${lib_name}"
 	@echo "lib_a         = ${lib_a}"
 	@echo "lib_so        = ${lib_so}"
 	@echo "lib           = ${lib}"
 	@echo "lib_so_abi    = ${lib_so_abi}"
 	@echo "lib_soname    = ${lib_soname}"
+	@echo
+	@echo "pkg           = ${pkg}"
 	@echo
 	@echo "lib_src       = ${lib_src}"
 	@echo
@@ -403,9 +413,11 @@ echo:
 	@echo "testsweeper_src   = ${testsweeper_src}"
 	@echo "testsweeper       = ${testsweeper}"
 	@echo
+	@echo "---------- C++ compiler"
 	@echo "CXX           = ${CXX}"
 	@echo "CXXFLAGS      = ${CXXFLAGS}"
 	@echo
+	@echo "---------- Link flags"
 	@echo "LD            = ${LD}"
 	@echo "LDFLAGS       = ${LDFLAGS}"
 	@echo "LIBS          = ${LIBS}"


### PR DESCRIPTION
Discovered the issue isn't with using braces on `${findstring ...}` and `${filter ...}` per se, but only when used as the 1st argument of `ifneq` or `ifeq`. GNU make raises an error saying it can't find the matching brace. Moving them to the 2nd argument works fine.