### PR TITLE
Remove unimplemented symv declarations

### DIFF
--- a/include/blas/wrappers.hh
+++ b/include/blas/wrappers.hh
@@ -528,6 +528,7 @@ void her2(
     std::complex<double>*       A, int64_t lda );
 
 //------------------------------------------------------------------------------
+// FIXME: only real; complex in lapack++
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,
@@ -548,28 +549,8 @@ void symv(
     double beta,
     double*       y, int64_t incy );
 
-void symv(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    int64_t n,
-    std::complex<float> alpha,
-    std::complex<float> const* A, int64_t lda,
-    std::complex<float> const* x, int64_t incx,
-    std::complex<float> beta,
-    std::complex<float>*       y, int64_t incy );
-
-void symv(
-    blas::Layout layout,
-    blas::Uplo uplo,
-    int64_t n,
-    std::complex<double> alpha,
-    std::complex<double> const* A, int64_t lda,
-    std::complex<double> const* x, int64_t incx,
-    std::complex<double> beta,
-    std::complex<double>*       y, int64_t incy );
-
 //------------------------------------------------------------------------------
-// only real; complex in lapack++
+// FIXME: only real; complex in lapack++
 void syr(
     blas::Layout layout,
     blas::Uplo uplo,


### PR DESCRIPTION
This PR removes the complex `symv` declarations from `wrappers.hh`, as these are currently not included in BLAS++.

The presence of these declarations cause a linking error if they are used, whereas without them uses safely fall back to the generic templated implementation in `symv.hh`.

Until these are moved back from LAPACK++ to BLAS++, as apparently is intended, this PR fixes the linking error.