### PR TITLE
use to_blas_int to check overflow and convert int64_t

### DIFF
--- a/src/rot.cc
+++ b/src/rot.cc
@@ -5,6 +5,7 @@
 
 #include "blas/fortran.h"
 #include "blas.hh"
+#include "blas_internal.hh"
 #include "blas/counter.hh"
 
 #include <limits>
@@ -29,13 +30,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -47,9 +41,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_srot( &n_, x, &incx_, y, &incy_, &c, &s );
 }
 
@@ -67,13 +62,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -85,9 +73,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_drot( &n_, x, &incx_, y, &incy_, &c, &s );
 }
 
@@ -110,13 +99,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -128,9 +110,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_csrot( &n_,
                 (blas_complex_float*) x, &incx_,
                 (blas_complex_float*) y, &incy_,
@@ -152,13 +135,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -170,9 +146,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_zdrot( &n_,
                 (blas_complex_double*) x, &incx_,
                 (blas_complex_double*) y, &incy_,
@@ -197,13 +174,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -215,9 +185,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_crot( &n_,
                (blas_complex_float*) x, &incx_,
                (blas_complex_float*) y, &incy_,
@@ -240,13 +211,6 @@ void rot(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rot_type element;
@@ -258,9 +222,10 @@ void rot(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_zrot( &n_,
                (blas_complex_double*) x, &incx_,
                (blas_complex_double*) y, &incy_,

--- a/src/rotm.cc
+++ b/src/rotm.cc
@@ -5,6 +5,7 @@
 
 #include "blas/fortran.h"
 #include "blas.hh"
+#include "blas_internal.hh"
 #include "blas/counter.hh"
 
 #include <limits>
@@ -29,13 +30,6 @@ void rotm(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rotm_type element;
@@ -47,9 +41,10 @@ void rotm(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_srotm( &n_, x, &incx_, y, &incy_, param );
 }
 
@@ -66,13 +61,6 @@ void rotm(
     blas_error_if( incx == 0 );  // standard BLAS doesn't detect inc[xy] == 0
     blas_error_if( incy == 0 );
 
-    // check for overflow in native BLAS integer type, if smaller than int64_t
-    if (sizeof(int64_t) > sizeof(blas_int)) {
-        blas_error_if( n              > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incx) > std::numeric_limits<blas_int>::max() );
-        blas_error_if( std::abs(incy) > std::numeric_limits<blas_int>::max() );
-    }
-
     #ifdef BLAS_HAVE_PAPI
         // PAPI instrumentation
         counter::rotm_type element;
@@ -84,9 +72,10 @@ void rotm(
         counter::inc_flop_count( (long long int)gflops );
     #endif
 
-    blas_int n_    = (blas_int) n;
-    blas_int incx_ = (blas_int) incx;
-    blas_int incy_ = (blas_int) incy;
+    // convert arguments
+    blas_int n_    = to_blas_int( n );
+    blas_int incx_ = to_blas_int( incx );
+    blas_int incy_ = to_blas_int( incy );
     BLAS_drotm( &n_, x, &incx_, y, &incy_, param );
 }
 


### PR DESCRIPTION
Updates rot, rotm. Other routines already used `to_blas_int`. Check files:
```
blaspp/src> git re -l '\bblas_int\b' | xargs grep -L to_blas_int

blaspp/src> git re -l '\bdevice_blas_int\b' | xargs grep -L to_device_blas_int
cublas_wrappers.cc
device_utils.cc
onemkl_wrappers.cc
rocblas_wrappers.cc

blaspp/src> git re numeric_limits
blas_internal.hh:        blas_error_if_msg( x > std::numeric_limits<blas_int>::max(), "%s", x_str );
device_internal.hh:        blas_error_if_msg( std::abs( x ) > std::numeric_limits<device_blas_int>::max(),
```