### PR TITLE
Fix for test error with Intel compiler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.device }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Configure
         run: .github/workflows/configure.sh ${{matrix.maker}} ${{matrix.device}}
       - name: Build

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -397,7 +397,7 @@ void test_device_routines()
 {
     printf( "%s\n", __func__ );
 
-    int repeat = 4;
+    const int repeat = 4;
     double t;
     int device_cnt;
 


### PR DESCRIPTION
With the 2024 version of the oneapi compilers, the following error occurs:

```
/tmp/blaspp/test/test_util.cc:566:45: error: variable length arrays in C++ are a Clang extension [-Werror,-Wvla-cxx-extension]
  566 |         blas::Queue::stream_t* stream_ptrs[ MAX_DEVICES * repeat ];
      |                                             ^~~~~~~~~~~~~~~~~~~~
/tmp/blaspp/test/test_util.cc:566:59: note: read of non-const variable 'repeat' is not allowed in a constant expression
  566 |         blas::Queue::stream_t* stream_ptrs[ MAX_DEVICES * repeat ];
      |                                                           ^
/tmp/blaspp/test/test_util.cc:400:9: note: declared here
  400 |     int repeat = 4;
      |         ^
```

This fix makes 'repeat' a const.