### PR TITLE
config: check for libatomic. Fixes #90.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ set_property( CACHE gpu_backend PROPERTY STRINGS
 
 # After color.
 include( "cmake/util.cmake" )
+include( "cmake/config.cmake" )
 
 # Recognize CTest's BUILD_TESTING flag. (Quotes required.)
 if (NOT "${BUILD_TESTING}" STREQUAL "")
@@ -357,7 +358,6 @@ endif()
 
 #-------------------------------------------------------------------------------
 # Clean stale defines.h from Makefile-based build.
-message( "" )
 file( REMOVE "${CMAKE_CURRENT_SOURCE_DIR}/include/blas/defines.h" )
 
 # Include directory.
@@ -371,6 +371,8 @@ target_include_directories(
 )
 
 # OpenMP support.
+message( "" )
+message( STATUS "${bold}Looking for OpenMP${not_bold}" )
 set( openmp_lib "" )
 set( blaspp_use_openmp false )  # output in blasppConfig.cmake.in
 if (NOT use_openmp)
@@ -384,7 +386,15 @@ else()
     endif()
 endif()
 
+# If -latomic is required, add as link library to blaspp.
+message( "" )
+check_libatomic()
+if (libatomic_required)
+    target_link_libraries( blaspp PUBLIC "-latomic" )
+endif()
+
 # Get git commit id.
+message( "" )
 if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/.git")
     execute_process( COMMAND git rev-parse --short HEAD
                      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -1,0 +1,52 @@
+# Copyright (c) 2017-2024, University of Tennessee. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#-------------------------------------------------------------------------------
+# Tests whether using `std::atomic` requires linking with `-latomic`
+# for 64-bit values, which is the case on some 32-bit systems.
+# Sets variable `libatomic_required`.
+#
+function( check_libatomic )
+    message( STATUS "Checking whether std::atomic requires libatomic" )
+    set( libatomic_required false )
+
+    try_compile(
+        link_result ${CMAKE_CURRENT_BINARY_DIR}
+        SOURCES
+            "${CMAKE_CURRENT_SOURCE_DIR}/config/std_atomic.cc"
+        OUTPUT_VARIABLE
+            link_output
+    )
+    debug_try_compile( "std_atomic.cc" "${link_result}" "${link_output}" )
+
+    set( label "   std::atomic links without -latomic" )
+    pad_string( "${label}" 50 label )
+    if (link_result)
+        message( "${label} ${blue} yes${plain}" )
+    else()
+        message( "${label} ${red} no${plain}" )
+
+        try_compile(
+            link_result ${CMAKE_CURRENT_BINARY_DIR}
+            SOURCES
+                "${CMAKE_CURRENT_SOURCE_DIR}/config/std_atomic.cc"
+            LINK_LIBRARIES
+                "-latomic"
+            OUTPUT_VARIABLE
+                link_output
+        )
+        debug_try_compile( "std_atomic.cc" "${link_result}" "${link_output}" )
+
+        set( label "   std::atomic requires -latomic" )
+        pad_string( "${label}" 50 label )
+        if (link_result)
+            #target_link_libraries( ${tgt} PUBLIC "-latomic" )
+            message( "${label} ${blue} yes${plain}" )
+            set( libatomic_required true )
+        else()
+            message( "${label} ${red} failed; cannot compile libatomic test${plain}" )
+        endif()
+    endif()
+endfunction()

--- a/config/config.py
+++ b/config/config.py
@@ -785,6 +785,27 @@ def gpu_blas():
 # end
 
 #-------------------------------------------------------------------------------
+def libatomic():
+    '''
+    Tests whether using `std::atomic` requires linking with `-latomic`
+    for 64-bit values, which is the case on some 32-bit systems.
+    If so, adds `-latomic` to LIBS.
+    '''
+    print_test( 'std::atomic links without -latomic' )
+    (rc, out, err) = compile_exe( 'config/std_atomic.cc' )
+    print_result( 'x', rc )
+    if (rc != 0):
+        print_test( 'std::atomic requires -latomic' )
+        env = {'LIBS': '-latomic'}
+        (rc, out, err) = compile_exe( 'config/std_atomic.cc', env )
+        print_result( 'x', rc )
+        if (rc == 0):
+            environ.merge( env )
+        else:
+            raise Error( 'cannot compile libatomic test' )
+# end
+
+#-------------------------------------------------------------------------------
 def get_package( name, directories, repo_url, tar_url, tar_filename ):
     '''
     Searches for a package, generally used for internal packages.

--- a/config/std_atomic.cc
+++ b/config/std_atomic.cc
@@ -1,0 +1,16 @@
+// Copyright (c) 2017-2024, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include <atomic>
+#include <cstdint>
+
+int main( int argc, char** argv )
+{
+    std::atomic<std::int64_t> x = 0;
+    for (int i = 1; i < argc; ++i) {
+        ++x;
+    }
+    return x;
+}

--- a/configure.py
+++ b/configure.py
@@ -57,6 +57,9 @@ def main():
    #config.prog_cxx_flag( '-Wconversion' )
    #config.prog_cxx_flag( '-Werror' )
 
+    print_header( 'Libraries' )
+    config.libatomic()
+
     config.openmp()
 
     config.lapack.blas()


### PR DESCRIPTION
See discussion in #90.
- [x] configure.py
- [x] CMake support