### PR TITLE
Converting HIP_PLATFORM_HCC to HIP_PLATFORM_AMD

### DIFF
--- a/config/rocblas.cc
+++ b/config/rocblas.cc
@@ -3,8 +3,8 @@
 // This program is free software: you can redistribute it and/or modify it under
 // the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
 
-#ifndef __HIP_PLATFORM_HCC__
-#define __HIP_PLATFORM_HCC__
+#ifndef __HIP_PLATFORM_AMD__
+#define __HIP_PLATFORM_AMD__
 #endif
 
 #include <hip/hip_runtime.h>

--- a/include/blas/device.hh
+++ b/include/blas/device.hh
@@ -20,10 +20,10 @@
     #include <cublas_v2.h>
 
 #elif defined(BLAS_HAVE_ROCBLAS)
-    // Default to HCC platform on ROCm
-    #if ! defined(__HIP_PLATFORM_NVCC__) && ! defined(__HIP_PLATFORM_HCC__)
-        #define __HIP_PLATFORM_HCC__
-        #define BLAS_HIP_PLATFORM_HCC
+    // Default to AMD platform on ROCm
+    #if ! defined(__HIP_PLATFORM_NVCC__) && ! defined(__HIP_PLATFORM_AMD__)
+        #define __HIP_PLATFORM_AMD__
+        #define BLAS_HIP_PLATFORM_AMD
     #endif
 
     #include <hip/hip_runtime.h>
@@ -35,10 +35,10 @@
         #include <rocblas.h>
     #endif
 
-    // If we defined __HIP_PLATFORM_HCC__, undef it.
-    #ifdef BLAS_HIP_PLATFORM_HCC
-        #undef __HIP_PLATFORM_HCC__
-        #undef BLAS_HIP_PLATFORM_HCC
+    // If we defined __HIP_PLATFORM_AMD__, undef it.
+    #ifdef BLAS_HIP_PLATFORM_AMD
+        #undef __HIP_PLATFORM_AMD__
+        #undef BLAS_HIP_PLATFORM_AMD
     #endif
 
 #elif defined(BLAS_HAVE_SYCL)


### PR DESCRIPTION
Use of HIP_PLATFORM_HCC is deprecated and breaking the build when using rocm 6.3.2.  Switching to use HIP_PLATFORM_AMD.