### PR TITLE
CMake match

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -70,6 +70,8 @@ BLAS++ specific options include (all values are case insensitive):
         auto            search for both threaded and sequential BLAS (default)
         yes             multi-threaded BLAS
         no              sequential BLAS
+        openmp_aware    acts as sequential BLAS inside OpenMP parallel
+                        sections; MKL does this.
 
     blas_fortran
         Fortran interface to use. Currently applies only to Intel MKL.

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -66,3 +66,24 @@ function( assert var )
         message( FATAL_ERROR "\n${red}Assertion failed: ${var} (value is '${${var}}')${default_color}\n" )
     endif()
 endfunction()
+
+#-------------------------------------------------------------------------------
+# match( regex str output )
+# If str matches regular expression in regex,
+# sets output to true, else sets it to false.
+#
+# Contrast this with: string( REGEX MATCH regex output str ),
+# which sets output to the match string itself, which could be false, e.g.,
+#     string( REGEX MATCH "(yes|no)" output "no" )
+# sets output = 'no' (interpreted as false in CMake), rather than true.
+#
+# The order of arguments here matches string( COMPARE EQUAL str1 str2 output ),
+# rather than string( REGEX MATCH regex output str ).
+#
+function( match regex str output )
+    if ("${str}" MATCHES "${regex}")
+        set( ${output} "true"  PARENT_SCOPE )
+    else()
+        set( ${output} "false" PARENT_SCOPE )
+    endif()
+endfunction()

--- a/config/lapack.py
+++ b/config/lapack.py
@@ -201,12 +201,13 @@ def blas():
 
     #-------------------- blas_threaded
     test_threaded   = re.search( r'\b(auto|y|yes|true|on|1)\b',  blas_threaded ) is not None
-    test_sequential = re.search( r'\b(auto|n|no|false|off|0)\b', blas_threaded ) is not None
-
+    test_sequential = re.search( r'\b(auto|n|no|false|off|0|openmp_aware)\b', blas_threaded ) is not None
+    test_threaded_omp = re.search( r'\bopenmp_aware\b', blas_threaded ) is not None
     if (config.debug()):
         print( "blas_threaded       = '" + blas_threaded + "'\n"
              + "test_threaded       = ", test_threaded,     "\n"
-             + "test_sequential     = ", test_sequential,   "\n" )
+             + "test_sequential     = ", test_sequential,   "\n"
+             + "test_threaded_omp   = ", test_threaded_omp, "\n" )
 
     #----------------------------------------
     # Build list of libraries to check.
@@ -229,7 +230,7 @@ def blas():
     if (test_mkl):
         choices_ifort    = []
         choices_gfortran = []
-        if (test_threaded and has_openmp):
+        if ((test_threaded or test_threaded_omp) and has_openmp):
             t_core = ' -lmkl_core -lm'
             if (test_gfortran and cxx_actual == 'g++'):
                 # GNU compiler + OpenMP: require gnu_thread library.


### PR DESCRIPTION
CMake updates:
* Use match() that sets boolean. The [CMake call](https://cmake.org/cmake/help/latest/command/string.html#regex-match) `string( REGEX MATCH regex output str )` stores the _actual_ matched string, not a boolean value. The actual matched string may be something that CMake considers false (no, false, 0, off, notfound, etc.), confounding the program logic.
* Add blas_threaded=openmp_aware, to allow linking with multi-threaded MKL in SLATE. Previously, SLATE by default restricts BLAS to sequential, since we want sequential BLAS in the OpenMP tasks. MKL is smart enough not to spawn new threads inside OpenMP tasks. [See MKL_DYNAMIC](https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2023-0/mkl-dynamic.html).