### PR TITLE
fix stdint.h

### DIFF
--- a/include/blas/util.hh
+++ b/include/blas/util.hh
@@ -14,6 +14,7 @@
 #include <algorithm>
 
 #include <assert.h>
+#include <stdint.h>
 
 namespace blas {
 


### PR DESCRIPTION
Fixes include error when compiling on Windows.