### PR TITLE
Add device hemv, symv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ add_library(
     src/device_gemm.cc
     src/device_gemv.cc
     src/device_hemm.cc
+    src/device_hemv.cc
     src/device_her2k.cc
     src/device_herk.cc
     src/device_iamax.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,7 @@ add_library(
     src/device_iamax.cc
     src/device_queue.cc
     src/device_symm.cc
+    src/device_symv.cc
     src/device_syr2k.cc
     src/device_syrk.cc
     src/device_asum.cc

--- a/include/blas/device_blas.hh
+++ b/include/blas/device_blas.hh
@@ -409,6 +409,51 @@ void gemv(
     blas::Queue& queue );
 
 //------------------------------------------------------------------------------
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
+    float beta,
+    float* y, int64_t incy,
+    blas::Queue& queue );
+
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
+    double beta,
+    double* y, int64_t incy,
+    blas::Queue& queue );
+
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> beta,
+    std::complex<float>* y, int64_t incy,
+    blas::Queue& queue );
+
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> beta,
+    std::complex<double>* y, int64_t incy,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void symv(
     blas::Layout layout,
     blas::Uplo uplo,

--- a/include/blas/device_blas.hh
+++ b/include/blas/device_blas.hh
@@ -408,6 +408,51 @@ void gemv(
     std::complex<double>*       y, int64_t incy,
     blas::Queue& queue );
 
+//------------------------------------------------------------------------------
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
+    float beta,
+    float* y, int64_t incy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
+    double beta,
+    double* y, int64_t incy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> beta,
+    std::complex<float>* y, int64_t incy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> beta,
+    std::complex<double>* y, int64_t incy,
+    blas::Queue& queue );
+
 //==============================================================================
 // Level 3 BLAS
 

--- a/src/cublas_wrappers.cc
+++ b/src/cublas_wrappers.cc
@@ -1055,6 +1055,54 @@ void gemv(
 }
 
 //------------------------------------------------------------------------------
+// hemv
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasChemv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            (cuComplex*) &alpha,
+            (cuComplex*) dA, ldda,
+            (cuComplex*) dx, incdx,
+            (cuComplex*) &beta,
+            (cuComplex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasZhemv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            (cuDoubleComplex*) &alpha,
+            (cuDoubleComplex*) dA, ldda,
+            (cuDoubleComplex*) dx, incdx,
+            (cuDoubleComplex*) &beta,
+            (cuDoubleComplex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
 // symv
 //------------------------------------------------------------------------------
 void symv(

--- a/src/cublas_wrappers.cc
+++ b/src/cublas_wrappers.cc
@@ -1054,6 +1054,96 @@ void gemv(
             (cuDoubleComplex*) dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// symv
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* dA, int64_t ldda,
+    float const* dx, int64_t incdx,
+    float beta,
+    float*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasSsymv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            &alpha, dA, ldda,
+                    dx, incdx,
+            &beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* dA, int64_t ldda,
+    double const* dx, int64_t incdx,
+    double beta,
+    double*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasDsymv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            &alpha, dA, ldda,
+                    dx, incdx,
+            &beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasCsymv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            (cuComplex*) &alpha,
+            (cuComplex*) dA, ldda,
+            (cuComplex*) dx, incdx,
+            (cuComplex*) &beta,
+            (cuComplex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasZsymv(
+            queue.handle(),
+            uplo2cublas( uplo ),
+            n,
+            (cuDoubleComplex*) &alpha,
+            (cuDoubleComplex*) dA, ldda,
+            (cuDoubleComplex*) dx, incdx,
+            (cuDoubleComplex*) &beta,
+            (cuDoubleComplex*) dy, incdy ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/device_hemv.cc
+++ b/src/device_hemv.cc
@@ -1,0 +1,179 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "blas/device_blas.hh"
+#include "blas/counter.hh"
+
+#include "device_internal.hh"
+
+#include <limits>
+#include <string.h>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup hemv_internal
+///
+template <typename scalar_t>
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    scalar_t alpha,
+    scalar_t const* A, int64_t lda,
+    scalar_t const* x, int64_t incx,
+    scalar_t beta,
+    scalar_t*       y, int64_t incy,
+    blas::Queue& queue )
+{
+#ifndef BLAS_HAVE_DEVICE
+    throw blas::Error( "device BLAS not available", __func__ );
+#else
+    static_assert( is_complex_v<scalar_t>, "complex version" );
+
+    // check arguments
+    blas_error_if( layout != Layout::ColMajor &&
+                   layout != Layout::RowMajor );
+    blas_error_if( uplo != Uplo::Upper &&
+                   uplo != Uplo::Lower );
+    blas_error_if( n < 0 );
+    blas_error_if( lda < n );
+    blas_error_if( incx == 0 );
+    blas_error_if( incy == 0 );
+
+    #ifdef BLAS_HAVE_PAPI
+        // PAPI instrumentation
+        counter::dev_hemv_type element;
+        memset( &element, 0, sizeof( element ) );
+        element = { uplo, n };
+        counter::insert( element, counter::Id::dev_hemv );
+
+        double gflops = 1e9 * blas::Gflop< scalar_t >::hemv( n );
+        counter::inc_flop_count( (long long int)gflops );
+    #endif
+
+    // convert arguments
+    device_blas_int n_    = to_device_blas_int( n );
+    device_blas_int lda_  = to_device_blas_int( lda );
+    device_blas_int incx_ = to_device_blas_int( incx );
+    device_blas_int incy_ = to_device_blas_int( incy );
+
+    blas::internal_set_device( queue.device() );
+
+    // Deal with layout. RowMajor needs copy of x in x2;
+    // in other cases, x2 == x.
+    scalar_t* x2 = const_cast< scalar_t* >( x );
+    if (layout == Layout::RowMajor) {
+        // swap lower <=> upper
+        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+
+        // conjugate alpha, beta, x (in x2), and y (in-place)
+        alpha = conj( alpha );
+        beta  = conj( beta );
+
+        x2 = blas::device_malloc<scalar_t>( n, queue );
+        blas::conj( n, x, incx, x2, 1, queue );
+        incx_ = 1;
+
+        blas::conj( n, y, incy, y, incy, queue );
+    }
+    queue.sync();
+
+    // call low-level wrapper
+    internal::hemv( uplo, n_,
+                    alpha, A, lda_, x2, incx_, beta, y, incy_, queue );
+
+    if (layout == Layout::RowMajor) {
+        // y = conj( y )
+        blas::conj( n, y, incy, y, incy, queue );
+        queue.sync();
+        blas::device_free( x2, queue );
+    }
+#endif
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+
+//------------------------------------------------------------------------------
+/// GPU, float version.
+/// @ingroup hemv
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
+    float beta,
+    float*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    symv( layout, uplo, n,
+          alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, double version.
+/// @ingroup hemv
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
+    double beta,
+    double*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    symv( layout, uplo, n,
+          alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, complex<float> version.
+/// @ingroup hemv
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> beta,
+    std::complex<float>*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::hemv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, complex<double> version.
+/// @ingroup hemv
+void hemv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> beta,
+    std::complex<double>*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::hemv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+}  // namespace blas

--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -635,8 +635,6 @@ void copy(
 // Level 2 BLAS - Device Interfaces
 
 //------------------------------------------------------------------------------
-// gemv
-//------------------------------------------------------------------------------
 void gemv(
     blas::Op trans,
     device_blas_int m, device_blas_int n,
@@ -647,7 +645,6 @@ void gemv(
     float*       dy, device_blas_int incdy,
     blas::Queue& queue );
 
-//------------------------------------------------------------------------------
 void gemv(
     blas::Op trans,
     device_blas_int m, device_blas_int n,
@@ -658,7 +655,6 @@ void gemv(
     double*       dy, device_blas_int incdy,
     blas::Queue& queue );
 
-//------------------------------------------------------------------------------
 void gemv(
     blas::Op trans,
     device_blas_int m, device_blas_int n,
@@ -669,7 +665,6 @@ void gemv(
     std::complex<float>*       dy, device_blas_int incdy,
     blas::Queue& queue );
 
-//------------------------------------------------------------------------------
 void gemv(
     blas::Op trans,
     device_blas_int m, device_blas_int n,
@@ -678,6 +673,47 @@ void gemv(
     std::complex<double> const* dx, device_blas_int incdx,
     std::complex<double> beta,
     std::complex<double>*       dy, device_blas_int incdy,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* dA, int64_t ldda,
+    float const* dx, int64_t incdx,
+    float beta,
+    float*       dy, int64_t incdy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* dA, int64_t ldda,
+    double const* dx, int64_t incdx,
+    double beta,
+    double*       dy, int64_t incdy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue );
+
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
     blas::Queue& queue );
 
 //==============================================================================

--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -676,6 +676,27 @@ void gemv(
     blas::Queue& queue );
 
 //------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue );
+
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
 void symv(
     blas::Uplo uplo,
     int64_t n,

--- a/src/device_symv.cc
+++ b/src/device_symv.cc
@@ -1,0 +1,156 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "blas/device_blas.hh"
+#include "blas/counter.hh"
+
+#include "device_internal.hh"
+
+#include <limits>
+#include "blas/counter.hh"
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup symv_internal
+///
+template <typename scalar_t>
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    scalar_t alpha,
+    scalar_t const* A, int64_t lda,
+    scalar_t const* x, int64_t incx,
+    scalar_t beta,
+    scalar_t*       y, int64_t incy,
+    blas::Queue& queue )
+{
+#ifndef BLAS_HAVE_DEVICE
+    throw blas::Error( "device BLAS not available", __func__ );
+#else
+    // check arguments
+    blas_error_if( layout != Layout::ColMajor &&
+                   layout != Layout::RowMajor );
+    blas_error_if( uplo != Uplo::Upper &&
+                   uplo != Uplo::Lower );
+    blas_error_if( n < 0 );
+    blas_error_if( lda < n );
+    blas_error_if( incx == 0 );
+    blas_error_if( incy == 0 );
+
+    #ifdef BLAS_HAVE_PAPI
+        // PAPI instrumentation
+        counter::dev_symv_type element;
+        memset( &element, 0, sizeof( element ) );
+        element = { uplo, n };
+        counter::insert( element, counter::Id::dev_symv );
+
+        double gflops = 1e9 * blas::Gflop< scalar_t >::symv( n );
+        counter::inc_flop_count( (long long int)gflops );
+    #endif
+
+    // convert arguments
+    device_blas_int n_    = to_device_blas_int( n );
+    device_blas_int lda_  = to_device_blas_int( lda );
+    device_blas_int incx_ = to_device_blas_int( incx );
+    device_blas_int incy_ = to_device_blas_int( incy );
+
+    if (layout == Layout::RowMajor) {
+        // swap lower <=> upper
+        uplo = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+    }
+
+    blas::internal_set_device( queue.device() );
+
+    // call low-level wrapper
+    internal::symv( uplo, n_,
+                    alpha, A, lda_, x, incx_, beta, y, incy_, queue );
+#endif
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+
+//------------------------------------------------------------------------------
+/// GPU, float version.
+/// @ingroup symv
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* A, int64_t lda,
+    float const* x, int64_t incx,
+    float beta,
+    float*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::symv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, double version.
+/// @ingroup symv
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* A, int64_t lda,
+    double const* x, int64_t incx,
+    double beta,
+    double*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::symv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, complex<float> version.
+/// @ingroup symv
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float> const* x, int64_t incx,
+    std::complex<float> beta,
+    std::complex<float>*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::symv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU, complex<double> version.
+/// @ingroup symv
+void symv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double> const* x, int64_t incx,
+    std::complex<double> beta,
+    std::complex<double>*       y, int64_t incy,
+    blas::Queue& queue )
+{
+    impl::symv( layout, uplo, n,
+                alpha, A, lda, x, incx, beta, y, incy, queue );
+}
+
+}  // namespace blas

--- a/src/onemkl_wrappers.cc
+++ b/src/onemkl_wrappers.cc
@@ -1003,6 +1003,92 @@ void gemv(
             beta,  dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// symv
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* dA, int64_t ldda,
+    float const* dx, int64_t incdx,
+    float beta,
+    float*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::symv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* dA, int64_t ldda,
+    double const* dx, int64_t incdx,
+    double beta,
+    double*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::symv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::symv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::symv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/onemkl_wrappers.cc
+++ b/src/onemkl_wrappers.cc
@@ -1004,6 +1004,50 @@ void gemv(
 }
 
 //------------------------------------------------------------------------------
+// hemv
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::hemv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::hemv(
+            queue.stream(),
+            uplo2onemkl( uplo ),
+            n,
+            alpha, dA, ldda,
+                   dx, incdx,
+            beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
 // symv
 //------------------------------------------------------------------------------
 void symv(

--- a/src/rocblas_wrappers.cc
+++ b/src/rocblas_wrappers.cc
@@ -1027,6 +1027,96 @@ void gemv(
             (rocblas_double_complex*) dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// symv
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    float alpha,
+    float const* dA, int64_t ldda,
+    float const* dx, int64_t incdx,
+    float beta,
+    float*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_ssymv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            &alpha, dA, ldda,
+                    dx, incdx,
+            &beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    double alpha,
+    double const* dA, int64_t ldda,
+    double const* dx, int64_t incdx,
+    double beta,
+    double*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_dsymv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            &alpha, dA, ldda,
+                    dx, incdx,
+            &beta,  dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_csymv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            (rocblas_float_complex*) &alpha,
+            (rocblas_float_complex*) dA, ldda,
+            (rocblas_float_complex*) dx, incdx,
+            (rocblas_float_complex*) &beta,
+            (rocblas_float_complex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void symv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_zsymv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            (rocblas_double_complex*) &alpha,
+            (rocblas_double_complex*) dA, ldda,
+            (rocblas_double_complex*) dx, incdx,
+            (rocblas_double_complex*) &beta,
+            (rocblas_double_complex*) dy, incdy ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/rocblas_wrappers.cc
+++ b/src/rocblas_wrappers.cc
@@ -1028,6 +1028,54 @@ void gemv(
 }
 
 //------------------------------------------------------------------------------
+// hemv
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<float> alpha,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float> const* dx, int64_t incdx,
+    std::complex<float> beta,
+    std::complex<float>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_chemv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            (rocblas_float_complex*) &alpha,
+            (rocblas_float_complex*) dA, ldda,
+            (rocblas_float_complex*) dx, incdx,
+            (rocblas_float_complex*) &beta,
+            (rocblas_float_complex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
+void hemv(
+    blas::Uplo uplo,
+    int64_t n,
+    std::complex<double> alpha,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double> const* dx, int64_t incdx,
+    std::complex<double> beta,
+    std::complex<double>*       dy, int64_t incdy,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_zhemv(
+            queue.handle(),
+            uplo2rocblas( uplo ),
+            n,
+            (rocblas_double_complex*) &alpha,
+            (rocblas_double_complex*) dA, ldda,
+            (rocblas_double_complex*) dx, incdx,
+            (rocblas_double_complex*) &beta,
+            (rocblas_double_complex*) dy, incdy ) );
+}
+
+//------------------------------------------------------------------------------
 // symv
 //------------------------------------------------------------------------------
 void symv(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -115,6 +115,7 @@ add_executable(
     test_gemm_device.cc
     test_gemv_device.cc
     test_hemm_device.cc
+    test_hemv_device.cc
     test_her2k_device.cc
     test_herk_device.cc
     test_symm_device.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -118,6 +118,7 @@ add_executable(
     test_her2k_device.cc
     test_herk_device.cc
     test_symm_device.cc
+    test_symv_device.cc
     test_syr2k_device.cc
     test_syrk_device.cc
     test_trmm_device.cc

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -322,6 +322,7 @@ if (opts.blas2):
 if (opts.blas2_device):
     cmds += [
     [ 'dev-gemv',  dtype      + layout + align + trans + mn + incx + incy ],
+    [ 'dev-hemv',  dtype      + layout + align + uplo + n + incx + incy ],
     [ 'dev-symv',  dtype      + layout + align + uplo + n + incx + incy ],
     ]
 

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -321,7 +321,8 @@ if (opts.blas2):
     
 if (opts.blas2_device):
     cmds += [
-    [ 'dev-gemv',  dtype      + layout + align + trans + mn + incx + incy ]
+    [ 'dev-gemv',  dtype      + layout + align + trans + mn + incx + incy ],
+    [ 'dev-symv',  dtype      + layout + align + uplo + n + incx + incy ],
     ]
 
 # Level 3

--- a/test/test.cc
+++ b/test/test.cc
@@ -177,6 +177,9 @@ std::vector< testsweeper::routines_t > routines = {
     { "dev-gemv",         test_gemv_device,         Section::device_blas2   },
     { "",                 nullptr,                  Section::newline },
 
+    { "dev-symv",         test_symv_device,         Section::device_blas2   },
+    { "",                 nullptr,                  Section::newline },
+
     // Device Level 3 BLAS
     { "dev-gemm",         test_gemm_device,         Section::device_blas3   },
     { "",                 nullptr,                  Section::newline },

--- a/test/test.cc
+++ b/test/test.cc
@@ -177,6 +177,9 @@ std::vector< testsweeper::routines_t > routines = {
     { "dev-gemv",         test_gemv_device,         Section::device_blas2   },
     { "",                 nullptr,                  Section::newline },
 
+    { "dev-hemv",         test_symv_device,         Section::device_blas2   },
+    { "",                 nullptr,                  Section::newline },
+
     { "dev-symv",         test_symv_device,         Section::device_blas2   },
     { "",                 nullptr,                  Section::newline },
 

--- a/test/test.hh
+++ b/test/test.hh
@@ -253,6 +253,7 @@ void test_copy_device  ( Params& params, bool run );
 //------------------------------------------------------------------------------
 // Level 2 GPU BLAS
 void test_gemv_device  ( Params& params, bool run );
+void test_symv_device  ( Params& params, bool run );
 
 //------------------------------------------------------------------------------
 // Level 3 GPU BLAS

--- a/test/test.hh
+++ b/test/test.hh
@@ -253,6 +253,7 @@ void test_copy_device  ( Params& params, bool run );
 //------------------------------------------------------------------------------
 // Level 2 GPU BLAS
 void test_gemv_device  ( Params& params, bool run );
+void test_hemv_device  ( Params& params, bool run );
 void test_symv_device  ( Params& params, bool run );
 
 //------------------------------------------------------------------------------

--- a/test/test_hemv_device.cc
+++ b/test/test_hemv_device.cc
@@ -1,0 +1,200 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+
+// -----------------------------------------------------------------------------
+template <typename TA, typename TX, typename TY>
+void test_hemv_device_work( Params& params, bool run )
+{
+    using namespace testsweeper;
+    using std::abs, std::real, std::imag;
+    using blas::Uplo, blas::Layout, blas::max;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
+
+    // get & mark input values
+    blas::Layout layout = params.layout();
+    blas::Uplo uplo = params.uplo();
+    scalar_t alpha  = params.alpha.get<scalar_t>();
+    scalar_t beta   = params.beta.get<scalar_t>();
+    int64_t n       = params.dim.n();
+    int64_t incx    = params.incx();
+    int64_t incy    = params.incy();
+    int64_t device  = params.device();
+    int64_t align   = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.gflops();
+    params.gbytes();
+    params.ref_time();
+    params.ref_gflops();
+    params.ref_gbytes();
+
+    // adjust header to msec
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    // setup
+    int64_t lda = max( roundup( n, align ), 1 );
+    size_t size_A = size_t(lda)*n;
+    size_t size_x = max( (n - 1) * abs( incx ) + 1, 0 );
+    size_t size_y = max( (n - 1) * abs( incy ) + 1, 0 );
+    TA* A    = new TA[ size_A ];
+    TX* x    = new TX[ size_x ];
+    TY* y    = new TY[ size_y ];
+    TY* yref = new TY[ size_y ];
+
+    // device specifics
+    blas::Queue queue( device );
+    TA* dA;
+    TX* dx;
+    TY* dy;
+
+    dA = blas::device_malloc<TA>( size_A, queue );
+    dx = blas::device_malloc<TX>( size_x, queue );
+    dy = blas::device_malloc<TY>( size_y, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size_A, A );
+    lapack_larnv( idist, iseed, size_x, x );
+    lapack_larnv( idist, iseed, size_y, y );
+    cblas_copy( n, y, incy, yref, incy );
+
+    blas::device_copy_matrix( size_A, size_A, A, lda, dA, lda, queue );
+    blas::device_copy_vector( size_x, x, abs( incx ), dx, abs( incx ), queue );
+    blas::device_copy_vector( size_y, y, abs( incy ), dy, abs( incy ), queue );
+    queue.sync();
+
+    // norms for error check
+    real_t work[1];
+    real_t Anorm = lapack_lanhe( "f", to_c_string( uplo ), n, A, lda, work );
+    real_t Xnorm = cblas_nrm2( n, x, std::abs(incx) );
+    real_t Ynorm = cblas_nrm2( n, y, std::abs(incy) );
+
+    // test error exits
+    assert_throw( blas::hemv( Layout(0), uplo,     n, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::hemv( layout,    Uplo(0),  n, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::hemv( layout,    uplo,    -1, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::hemv( layout,    uplo,     n, alpha, dA, n-1, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::hemv( layout,    uplo,     n, alpha, dA, lda, dx,    0, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::hemv( layout,    uplo,     n, alpha, dA, lda, dx, incx, beta, dy,    0, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
+                "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
+                "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
+    }
+    if (verbose >= 2) {
+        printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",
+                real(alpha), imag(alpha),
+                real(beta),  imag(beta) );
+        printf( "A = "    ); print_matrix( n, n, A, lda );
+        printf( "x    = " ); print_vector( n, x, incx );
+        printf( "y    = " ); print_vector( n, y, incy );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+    double time = get_wtime();
+    blas::hemv( layout, uplo, n, alpha, dA, lda, dx, incx, beta, dy, incy, queue );
+    queue.sync();
+    time = get_wtime() - time;
+
+    double gflop = blas::Gflop< scalar_t >::hemv( n );
+    double gbyte = blas::Gbyte< scalar_t >::hemv( n );
+    params.time()   = time * 1000;  // msec
+    params.gflops() = gflop / time;
+    params.gbytes() = gbyte / time;
+    blas::device_copy_vector( size_y, dy, abs( incy ), y, abs( incy ), queue );
+    queue.sync();
+
+    if (verbose >= 2) {
+        printf( "y2   = " ); print_vector( n, y, incy );
+    }
+
+    if (params.check() == 'y') {
+        // run reference
+        testsweeper::flush_cache( params.cache() );
+        time = get_wtime();
+        cblas_hemv( cblas_layout_const(layout), cblas_uplo_const(uplo), n,
+                    alpha, A, lda, x, incx, beta, yref, incy );
+        time = get_wtime() - time;
+
+        params.ref_time()   = time * 1000;  // msec
+        params.ref_gflops() = gflop / time;
+        params.ref_gbytes() = gbyte / time;
+
+        if (verbose >= 2) {
+            printf( "yref = " ); print_vector( n, yref, incy );
+        }
+
+        // check error compared to reference
+        // treat y as 1 x leny matrix with ld = incy; k = lenx is reduction dimension
+        real_t error;
+        bool okay;
+        check_gemm( 1, n, n, alpha, beta, Anorm, Xnorm, Ynorm,
+                    yref, std::abs(incy), y, std::abs(incy), verbose, &error, &okay );
+        params.error() = error;
+        params.okay() = okay;
+    }
+
+    delete[] A;
+    delete[] x;
+    delete[] y;
+    delete[] yref;
+
+    blas::device_free( dA, queue );
+    blas::device_free( dx, queue );
+    blas::device_free( dy, queue );
+}
+
+// -----------------------------------------------------------------------------
+void test_hemv_device( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_hemv_device_work< float, float, float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_hemv_device_work< double, double, double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_hemv_device_work< std::complex<float>, std::complex<float>,
+                            std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_hemv_device_work< std::complex<double>, std::complex<double>,
+                            std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}

--- a/test/test_symv_device.cc
+++ b/test/test_symv_device.cc
@@ -1,0 +1,200 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+
+// -----------------------------------------------------------------------------
+template <typename TA, typename TX, typename TY>
+void test_symv_device_work( Params& params, bool run )
+{
+    using namespace testsweeper;
+    using std::abs, std::real, std::imag;
+    using blas::Uplo, blas::Layout, blas::max;
+    using scalar_t = blas::scalar_type< TA, TX, TY >;
+    using real_t   = blas::real_type< scalar_t >;
+
+    // get & mark input values
+    blas::Layout layout = params.layout();
+    blas::Uplo uplo = params.uplo();
+    scalar_t alpha  = params.alpha.get<scalar_t>();
+    scalar_t beta   = params.beta.get<scalar_t>();
+    int64_t n       = params.dim.n();
+    int64_t incx    = params.incx();
+    int64_t incy    = params.incy();
+    int64_t device  = params.device();
+    int64_t align   = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.gflops();
+    params.gbytes();
+    params.ref_time();
+    params.ref_gflops();
+    params.ref_gbytes();
+
+    // adjust header to msec
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    // setup
+    int64_t lda = max( roundup( n, align ), 1 );
+    size_t size_A = size_t(lda)*n;
+    size_t size_x = max( (n - 1) * abs( incx ) + 1, 0 );
+    size_t size_y = max( (n - 1) * abs( incy ) + 1, 0 );
+    TA* A    = new TA[ size_A ];
+    TX* x    = new TX[ size_x ];
+    TY* y    = new TY[ size_y ];
+    TY* yref = new TY[ size_y ];
+
+    // device specifics
+    blas::Queue queue( device );
+    TA* dA;
+    TX* dx;
+    TY* dy;
+
+    dA = blas::device_malloc<TA>( size_A, queue );
+    dx = blas::device_malloc<TX>( size_x, queue );
+    dy = blas::device_malloc<TY>( size_y, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size_A, A );
+    lapack_larnv( idist, iseed, size_x, x );
+    lapack_larnv( idist, iseed, size_y, y );
+    cblas_copy( n, y, incy, yref, incy );
+
+    blas::device_copy_matrix( n, n, A, lda, dA, lda, queue );
+    blas::device_copy_vector( size_x, x, abs( incx ), dx, abs( incx ), queue );
+    blas::device_copy_vector( size_y, y, abs( incy ), dy, abs( incy ), queue );
+    queue.sync();
+
+    // norms for error check
+    real_t work[1];
+    real_t Anorm = lapack_lansy( "f", to_c_string( uplo ), n, A, lda, work );
+    real_t Xnorm = cblas_nrm2( n, x, std::abs(incx) );
+    real_t Ynorm = cblas_nrm2( n, y, std::abs(incy) );
+
+    // test error exits
+    assert_throw( blas::symv( Layout(0), uplo,     n, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::symv( layout,    Uplo(0),  n, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::symv( layout,    uplo,    -1, alpha, dA, lda, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::symv( layout,    uplo,     n, alpha, dA, n-1, dx, incx, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::symv( layout,    uplo,     n, alpha, dA, lda, dx,    0, beta, dy, incy, queue ), blas::Error );
+    assert_throw( blas::symv( layout,    uplo,     n, alpha, dA, lda, dx, incx, beta, dy,    0, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
+                "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n"
+                "y n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm,
+                llong( n ), llong( incy ), llong( size_y ), Ynorm );
+    }
+    if (verbose >= 2) {
+        printf( "alpha = %.4e + %.4ei; beta = %.4e + %.4ei;\n",
+                real(alpha), imag(alpha),
+                real(beta),  imag(beta) );
+        printf( "A = "    ); print_matrix( n, n, A, lda );
+        printf( "x    = " ); print_vector( n, x, incx );
+        printf( "y    = " ); print_vector( n, y, incy );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+    double time = get_wtime();
+    blas::symv( layout, uplo, n, alpha, dA, lda, dx, incx, beta, dy, incy, queue );
+    queue.sync();
+    time = get_wtime() - time;
+
+    double gflop = blas::Gflop< scalar_t >::symv( n );
+    double gbyte = blas::Gbyte< scalar_t >::symv( n );
+    params.time()   = time * 1000;  // msec
+    params.gflops() = gflop / time;
+    params.gbytes() = gbyte / time;
+    blas::device_copy_vector( size_y, dy, abs( incy ), y, abs( incy ), queue );
+    queue.sync();
+
+    if (verbose >= 2) {
+        printf( "y2   = " ); print_vector( n, y, incy );
+    }
+
+    if (params.check() == 'y') {
+        // run reference
+        testsweeper::flush_cache( params.cache() );
+        time = get_wtime();
+        cblas_symv( cblas_layout_const(layout), cblas_uplo_const(uplo), n,
+                    alpha, A, lda, x, incx, beta, yref, incy );
+        time = get_wtime() - time;
+
+        params.ref_time()   = time * 1000;  // msec
+        params.ref_gflops() = gflop / time;
+        params.ref_gbytes() = gbyte / time;
+
+        if (verbose >= 2) {
+            printf( "yref = " ); print_vector( n, yref, incy );
+        }
+
+        // check error compared to reference
+        // treat y as 1 x leny matrix with ld = incy; k = lenx is reduction dimension
+        real_t error;
+        bool okay;
+        check_gemm( 1, n, n, alpha, beta, Anorm, Xnorm, Ynorm,
+                    yref, std::abs(incy), y, std::abs(incy), verbose, &error, &okay );
+        params.error() = error;
+        params.okay() = okay;
+    }
+
+    delete[] A;
+    delete[] x;
+    delete[] y;
+    delete[] yref;
+
+    blas::device_free( dA, queue );
+    blas::device_free( dx, queue );
+    blas::device_free( dy, queue );
+}
+
+// -----------------------------------------------------------------------------
+void test_symv_device( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_symv_device_work< float, float, float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_symv_device_work< double, double, double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_symv_device_work< std::complex<float>, std::complex<float>,
+                            std::complex<float> >( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_symv_device_work< std::complex<double>, std::complex<double>,
+                            std::complex<double> >( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}


### PR DESCRIPTION
Added cuBLAS, rocBLAS, and oneMKL wrappers for symv and hemv. Based on #116.