### PR TITLE
Add device trmv, trsv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,7 +380,9 @@ add_library(
     src/device_rotm.cc
     src/device_rotmg.cc
     src/device_trmm.cc
+    src/device_trmv.cc
     src/device_trsm.cc
+    src/device_trsv.cc
     src/device_utils.cc
     src/cublas_wrappers.cc
     src/rocblas_wrappers.cc

--- a/include/blas/device_blas.hh
+++ b/include/blas/device_blas.hh
@@ -498,6 +498,88 @@ void symv(
     std::complex<double>* y, int64_t incy,
     blas::Queue& queue );
 
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double* x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue );
+
 //==============================================================================
 // Level 3 BLAS
 

--- a/src/cublas_wrappers.cc
+++ b/src/cublas_wrappers.cc
@@ -1192,6 +1192,162 @@ void symv(
             (cuDoubleComplex*) dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// trmv
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasStrmv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasDtrmv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasCtrmv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            (cuComplex*) dA, ldda,
+            (cuComplex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasZtrmv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            (cuDoubleComplex*) dA, ldda,
+            (cuDoubleComplex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+// trsv
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasStrsv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasDtrsv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasCtrsv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            (cuComplex*) dA, ldda,
+            (cuComplex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        cublasZtrsv(
+            queue.handle(),
+            uplo2cublas( uplo ), op2cublas( trans ), diag2cublas( diag ),
+            n,
+            (cuDoubleComplex*) dA, ldda,
+            (cuDoubleComplex*) dx, incdx ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/device_internal.hh
+++ b/src/device_internal.hh
@@ -737,6 +737,80 @@ void symv(
     std::complex<double>*       dy, int64_t incdy,
     blas::Queue& queue );
 
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double* x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue );
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue );
+
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue );
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/device_trmv.cc
+++ b/src/device_trmv.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "blas/device_blas.hh"
+#include "blas/counter.hh"
+
+#include "device_internal.hh"
+
+#include <limits>
+#include <string.h>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup trmv_internal
+///
+template <typename scalar_t>
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    scalar_t const* A, int64_t lda,
+    scalar_t*       x, int64_t incx,
+    blas::Queue& queue )
+{
+#ifndef BLAS_HAVE_DEVICE
+    throw blas::Error( "device BLAS not available", __func__ );
+#else
+    // check arguments
+    blas_error_if( layout != Layout::ColMajor &&
+                   layout != Layout::RowMajor );
+    blas_error_if( uplo != Uplo::Lower &&
+                   uplo != Uplo::Upper );
+    blas_error_if( trans != Op::NoTrans &&
+                   trans != Op::Trans &&
+                   trans != Op::ConjTrans );
+    blas_error_if( diag != Diag::NonUnit &&
+                   diag != Diag::Unit );
+    blas_error_if( n < 0 );
+    blas_error_if( lda < n );
+    blas_error_if( incx == 0 );
+
+    #ifdef BLAS_HAVE_PAPI
+        // PAPI instrumentation
+        counter::dev_trmv_type element;
+        memset( &element, 0, sizeof( element ) );
+        element = { uplo, trans, diag, n };
+        counter::insert( element, counter::Id::dev_trmv );
+
+        double gflops = 1e9 * blas::Gflop< scalar_t >::trmv( n );
+        counter::inc_flop_count( (long long int)gflops );
+    #endif
+
+    // convert arguments
+    device_blas_int n_    = to_device_blas_int( n );
+    device_blas_int lda_  = to_device_blas_int( lda );
+    device_blas_int incx_ = to_device_blas_int( incx );
+
+    blas::internal_set_device( queue.device() );
+
+    blas::Uplo uplo_  = uplo;
+    blas::Op   trans_ = trans;
+    blas::Diag diag_  = diag;
+    if (layout == Layout::RowMajor) {
+        // swap lower <=> upper
+        // A => A^T; A^T => A; A^H => A
+        uplo_ = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        trans_ = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
+
+        if constexpr (is_complex_v<scalar_t>) {
+            if (trans == Op::ConjTrans) {
+                // conjugate x (in-place)
+                blas::conj( n, x, incx, x, incx, queue );
+            }
+        }
+    }
+    queue.sync();
+
+    // call low-level wrapper
+    internal::trmv( uplo_, trans_, diag_, n_, A, lda_, x, incx_, queue );
+
+    if constexpr (is_complex_v<scalar_t>) {
+        if (layout == Layout::RowMajor && trans == Op::ConjTrans) {
+            // conjugate x (in-place)
+            blas::conj( n, x, incx, x, incx, queue );
+        }
+    }
+#endif
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+
+//------------------------------------------------------------------------------
+/// GPU device, float version.
+/// @ingroup trmv
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trmv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, double version.
+/// @ingroup trmv
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trmv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, complex<float> version.
+/// @ingroup trmv
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trmv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, complex<double> version.
+/// @ingroup trmv
+void trmv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trmv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+}  // namespace blas

--- a/src/device_trsv.cc
+++ b/src/device_trsv.cc
@@ -1,0 +1,169 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "blas/device_blas.hh"
+#include "blas/counter.hh"
+
+#include "device_internal.hh"
+
+#include <limits>
+#include <string.h>
+
+namespace blas {
+
+//==============================================================================
+namespace impl {
+
+//------------------------------------------------------------------------------
+/// Mid-level templated wrapper checks and converts arguments,
+/// then calls low-level wrapper.
+/// @ingroup trsv_internal
+///
+template <typename scalar_t>
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    scalar_t const* A, int64_t lda,
+    scalar_t*       x, int64_t incx,
+    blas::Queue& queue )
+{
+#ifndef BLAS_HAVE_DEVICE
+    throw blas::Error( "device BLAS not available", __func__ );
+#else
+    // check arguments
+    blas_error_if( layout != Layout::ColMajor &&
+                   layout != Layout::RowMajor );
+    blas_error_if( uplo != Uplo::Lower &&
+                   uplo != Uplo::Upper );
+    blas_error_if( trans != Op::NoTrans &&
+                   trans != Op::Trans &&
+                   trans != Op::ConjTrans );
+    blas_error_if( diag != Diag::NonUnit &&
+                   diag != Diag::Unit );
+    blas_error_if( n < 0 );
+    blas_error_if( lda < n );
+    blas_error_if( incx == 0 );
+
+    #ifdef BLAS_HAVE_PAPI
+        // PAPI instrumentation
+        counter::dev_trsv_type element;
+        memset( &element, 0, sizeof( element ) );
+        element = { uplo, trans, diag, n };
+        counter::insert( element, counter::Id::dev_trsv );
+
+        double gflops = 1e9 * blas::Gflop< scalar_t >::trsv( n );
+        counter::inc_flop_count( (long long int)gflops );
+    #endif
+
+    // convert arguments
+    device_blas_int n_    = to_device_blas_int( n );
+    device_blas_int lda_  = to_device_blas_int( lda );
+    device_blas_int incx_ = to_device_blas_int( incx );
+
+    blas::internal_set_device( queue.device() );
+
+    blas::Uplo uplo_  = uplo;
+    blas::Op   trans_ = trans;
+    blas::Diag diag_  = diag;
+    if (layout == Layout::RowMajor) {
+        // swap lower <=> upper
+        // A => A^T; A^T => A; A^H => A
+        uplo_ = (uplo == Uplo::Lower ? Uplo::Upper : Uplo::Lower);
+        trans_ = (trans == Op::NoTrans ? Op::Trans : Op::NoTrans);
+
+        if constexpr (is_complex_v<scalar_t>) {
+            if (trans == Op::ConjTrans) {
+                // conjugate x (in-place)
+                blas::conj( n, x, incx, x, incx, queue );
+            }
+        }
+    }
+    queue.sync();
+
+    // call low-level wrapper
+    internal::trsv( uplo_, trans_, diag_, n_, A, lda_, x, incx_, queue );
+
+    if constexpr (is_complex_v<scalar_t>) {
+        if (layout == Layout::RowMajor && trans == Op::ConjTrans) {
+            // conjugate x (in-place)
+            blas::conj( n, x, incx, x, incx, queue );
+        }
+    }
+#endif
+}
+
+}  // namespace impl
+
+//==============================================================================
+// High-level overloaded wrappers call mid-level templated wrapper.
+
+//------------------------------------------------------------------------------
+/// GPU device, float version.
+/// @ingroup trsv
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* A, int64_t lda,
+    float*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trsv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, double version.
+/// @ingroup trsv
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* A, int64_t lda,
+    double*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trsv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, complex<float> version.
+/// @ingroup trsv
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* A, int64_t lda,
+    std::complex<float>*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trsv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+//------------------------------------------------------------------------------
+/// GPU device, complex<double> version.
+/// @ingroup trsv
+void trsv(
+    blas::Layout layout,
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* A, int64_t lda,
+    std::complex<double>*       x, int64_t incx,
+    blas::Queue& queue )
+{
+    impl::trsv( layout, uplo, trans, diag, n, A, lda, x, incx, queue );
+}
+
+}  // namespace blas

--- a/src/onemkl_wrappers.cc
+++ b/src/onemkl_wrappers.cc
@@ -1133,6 +1133,162 @@ void symv(
             beta,  dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// trmv
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trmv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trmv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trmv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trmv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+// trsv
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trsv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trsv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trsv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        oneapi::mkl::blas::trsv(
+            queue.stream(),
+            uplo2onemkl( uplo ), op2onemkl( trans ), diag2onemkl( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/src/rocblas_wrappers.cc
+++ b/src/rocblas_wrappers.cc
@@ -1165,6 +1165,162 @@ void symv(
             (rocblas_double_complex*) dy, incdy ) );
 }
 
+//------------------------------------------------------------------------------
+// trmv
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_strmv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_dtrmv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_ctrmv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            (rocblas_float_complex*) dA, ldda,
+            (rocblas_float_complex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trmv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_ztrmv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            (rocblas_double_complex*) dA, ldda,
+            (rocblas_double_complex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+// trsv
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    float const* dA, int64_t ldda,
+    float*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_strsv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    double const* dA, int64_t ldda,
+    double*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_dtrsv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            dA, ldda,
+            dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<float> const* dA, int64_t ldda,
+    std::complex<float>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_ctrsv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            (rocblas_float_complex*) dA, ldda,
+            (rocblas_float_complex*) dx, incdx ) );
+}
+
+//------------------------------------------------------------------------------
+void trsv(
+    blas::Uplo uplo,
+    blas::Op trans,
+    blas::Diag diag,
+    int64_t n,
+    std::complex<double> const* dA, int64_t ldda,
+    std::complex<double>*       dx, int64_t incdx,
+    blas::Queue& queue )
+{
+    blas_dev_call(
+        rocblas_ztrsv(
+            queue.handle(),
+            uplo2rocblas( uplo ), op2rocblas( trans ), diag2rocblas( diag ),
+            n,
+            (rocblas_double_complex*) dA, ldda,
+            (rocblas_double_complex*) dx, incdx ) );
+}
+
 //==============================================================================
 // Level 3 BLAS - Device Interfaces
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,7 +123,9 @@ add_executable(
     test_syr2k_device.cc
     test_syrk_device.cc
     test_trmm_device.cc
+    test_trmv_device.cc
     test_trsm_device.cc
+    test_trsv_device.cc
 )
 
 # C++11 is inherited from blaspp, but disabling extensions is not.

--- a/test/run_tests.py
+++ b/test/run_tests.py
@@ -324,6 +324,8 @@ if (opts.blas2_device):
     [ 'dev-gemv',  dtype      + layout + align + trans + mn + incx + incy ],
     [ 'dev-hemv',  dtype      + layout + align + uplo + n + incx + incy ],
     [ 'dev-symv',  dtype      + layout + align + uplo + n + incx + incy ],
+    [ 'dev-trmv',  dtype      + layout + align + uplo + trans + diag + n + incx ],
+    [ 'dev-trsv',  dtype      + layout + align + uplo + trans + diag + n + incx ],
     ]
 
 # Level 3

--- a/test/test.cc
+++ b/test/test.cc
@@ -183,6 +183,10 @@ std::vector< testsweeper::routines_t > routines = {
     { "dev-symv",         test_symv_device,         Section::device_blas2   },
     { "",                 nullptr,                  Section::newline },
 
+    { "dev-trmv",         test_trmv_device,         Section::device_blas2   },
+    { "dev-trsv",         test_trsv_device,         Section::device_blas2   },
+    { "",                 nullptr,                  Section::newline },
+
     // Device Level 3 BLAS
     { "dev-gemm",         test_gemm_device,         Section::device_blas3   },
     { "",                 nullptr,                  Section::newline },

--- a/test/test.hh
+++ b/test/test.hh
@@ -255,6 +255,8 @@ void test_copy_device  ( Params& params, bool run );
 void test_gemv_device  ( Params& params, bool run );
 void test_hemv_device  ( Params& params, bool run );
 void test_symv_device  ( Params& params, bool run );
+void test_trmv_device  ( Params& params, bool run );
+void test_trsv_device  ( Params& params, bool run );
 
 //------------------------------------------------------------------------------
 // Level 3 GPU BLAS

--- a/test/test_trmv_device.cc
+++ b/test/test_trmv_device.cc
@@ -1,0 +1,192 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+
+// -----------------------------------------------------------------------------
+template <typename TA, typename TX>
+void test_trmv_device_work( Params& params, bool run )
+{
+    using namespace testsweeper;
+    using std::abs;
+    using blas::Uplo, blas::Op, blas::Layout, blas::Diag, blas::max;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
+
+    // get & mark input values
+    blas::Layout layout = params.layout();
+    blas::Uplo uplo = params.uplo();
+    blas::Op trans  = params.trans();
+    blas::Diag diag = params.diag();
+    int64_t n       = params.dim.n();
+    int64_t incx    = params.incx();
+    int64_t device  = params.device();
+    int64_t align   = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.gflops();
+    params.gbytes();
+    params.ref_time();
+    params.ref_gflops();
+    params.ref_gbytes();
+
+    // adjust header to msec
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    // ----------
+    // setup
+    int64_t lda = max( roundup( n, align ), 1 );
+    size_t size_A = size_t(lda)*n;
+    size_t size_x = max( (n - 1) * abs( incx ) + 1, 0 );
+    TA* A    = new TA[ size_A ];
+    TX* x    = new TX[ size_x ];
+    TX* xref = new TX[ size_x ];
+
+    // device specifics
+    blas::Queue queue( device );
+    TA* dA;
+    TX* dx;
+
+    dA = blas::device_malloc<TA>( size_A, queue );
+    dx = blas::device_malloc<TX>( size_x, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size_A, A );  // TODO: generate
+    lapack_larnv( idist, iseed, size_x, x );  // TODO
+    cblas_copy( n, x, incx, xref, incx );
+
+    blas::device_copy_matrix( n, n, A, lda, dA, lda, queue );
+    blas::device_copy_vector( n, x, abs( incx ), dx, abs( incx ), queue );
+    queue.sync();
+
+    // norms for error check
+    real_t work[1];
+    real_t Anorm = lapack_lantr( "f", to_c_string( uplo ), to_c_string( diag ),
+                                 n, n, A, lda, work );
+    real_t Xnorm = cblas_nrm2( n, x, std::abs(incx) );
+
+    // test error exits
+    assert_throw( blas::trmv( Layout(0), uplo,    trans, diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    Uplo(0), trans, diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    uplo,    Op(0), diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    uplo,    trans, Diag(0),  n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    uplo,    trans, diag,    -1, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    uplo,    trans, diag,     n, dA, n-1, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trmv( layout,    uplo,    trans, diag,     n, dA, lda, dx,    0, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
+                "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
+    }
+    if (verbose >= 2) {
+        printf( "A = "    ); print_matrix( n, n, A, lda );
+        printf( "x    = " ); print_vector( n, x, incx );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+    double time = get_wtime();
+    blas::trmv( layout, uplo, trans, diag, n, dA, lda, dx, incx, queue );
+    queue.sync();
+    time = get_wtime() - time;
+
+    double gflop = blas::Gflop< scalar_t >::trmv( n );
+    double gbyte = blas::Gbyte< scalar_t >::trmv( n );
+    params.time()   = time * 1000;  // msec
+    params.gflops() = gflop / time;
+    params.gbytes() = gbyte / time;
+
+    blas::device_copy_vector( n, dx, abs( incx ), x, abs( incx ), queue );
+    queue.sync();
+
+    if (verbose >= 2) {
+        printf( "x2   = " ); print_vector( n, x, incx );
+    }
+
+    if (params.check() == 'y') {
+        // run reference
+        testsweeper::flush_cache( params.cache() );
+        time = get_wtime();
+        cblas_trmv( cblas_layout_const(layout),
+                    cblas_uplo_const(uplo),
+                    cblas_trans_const(trans),
+                    cblas_diag_const(diag),
+                    n, A, lda, xref, incx );
+        time = get_wtime() - time;
+
+        params.ref_time()   = time * 1000;  // msec
+        params.ref_gflops() = gflop / time;
+        params.ref_gbytes() = gbyte / time;
+
+        if (verbose >= 2) {
+            printf( "xref = " ); print_vector( n, xref, incx );
+        }
+
+        // check error compared to reference
+        // treat x as 1 x n matrix with ld = incx; k = n is reduction dimension
+        // alpha = 1, beta = 0.
+        real_t error;
+        bool okay;
+        check_gemm( 1, n, n, scalar_t(1), scalar_t(0), Anorm, Xnorm, real_t(0),
+                    xref, std::abs(incx), x, std::abs(incx), verbose, &error, &okay );
+        params.error() = error;
+        params.okay() = okay;
+    }
+
+    delete[] A;
+    delete[] x;
+    delete[] xref;
+
+    blas::device_free( dA, queue );
+    blas::device_free( dx, queue );
+}
+
+// -----------------------------------------------------------------------------
+void test_trmv_device( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_trmv_device_work< float, float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_trmv_device_work< double, double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_trmv_device_work< std::complex<float>, std::complex<float> >
+                ( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_trmv_device_work< std::complex<double>, std::complex<double> >
+                ( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}

--- a/test/test_trsv_device.cc
+++ b/test/test_trsv_device.cc
@@ -1,0 +1,226 @@
+// Copyright (c) 2017-2023, University of Tennessee. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the BSD 3-Clause license. See the accompanying LICENSE file.
+
+#include "test.hh"
+#include "cblas_wrappers.hh"
+#include "lapack_wrappers.hh"
+#include "blas/flops.hh"
+#include "print_matrix.hh"
+#include "check_gemm.hh"
+
+// -----------------------------------------------------------------------------
+template <typename TA, typename TX>
+void test_trsv_device_work( Params& params, bool run )
+{
+    #define A(i_, j_) A[ (i_) + (j_)*lda ]
+
+    using namespace testsweeper;
+    using blas::Uplo, blas::Op, blas::Layout, blas::Diag, blas::max;
+    using scalar_t = blas::scalar_type< TA, TX >;
+    using real_t   = blas::real_type< scalar_t >;
+    using std::abs, std::swap;
+
+    // get & mark input values
+    blas::Layout layout = params.layout();
+    blas::Uplo uplo = params.uplo();
+    blas::Op trans  = params.trans();
+    blas::Diag diag = params.diag();
+    int64_t n       = params.dim.n();
+    int64_t incx    = params.incx();
+    int64_t device  = params.device();
+    int64_t align   = params.align();
+    int64_t verbose = params.verbose();
+
+    // mark non-standard output values
+    params.gflops();
+    params.gbytes();
+    params.ref_time();
+    params.ref_gflops();
+    params.ref_gbytes();
+
+    // adjust header to msec
+    params.time.name( "time (ms)" );
+    params.ref_time.name( "ref time (ms)" );
+    params.ref_time.width( 13 );
+
+    if (! run)
+        return;
+
+    if (blas::get_device_count() == 0) {
+        params.msg() = "skipping: no GPU devices or no GPU support";
+        return;
+    }
+
+    // setup
+    int64_t lda = max( roundup( n, align ), 1 );
+    size_t size_A = size_t(lda)*n;
+    size_t size_x = max( (n - 1) * abs( incx ) + 1, 0 );
+    TA* A    = new TA[ size_A ];
+    TX* x    = new TX[ size_x ];
+    TX* xref = new TX[ size_x ];
+
+    // device specifics
+    blas::Queue queue( device );
+    TA* dA;
+    TX* dx;
+
+    dA = blas::device_malloc<TA>( size_A, queue );
+    dx = blas::device_malloc<TX>( size_x, queue );
+
+    int64_t idist = 1;
+    int iseed[4] = { 0, 0, 0, 1 };
+    lapack_larnv( idist, iseed, size_A, A );
+    lapack_larnv( idist, iseed, size_x, x );
+    cblas_copy( n, x, incx, xref, incx );
+
+    // set unused data to nan
+    if (uplo == Uplo::Lower) {
+        for (int64_t j = 0; j < n; ++j)
+            for (int64_t i = 0; i < j; ++i)  // upper
+                A( i, j ) = nan("");
+    }
+    else {
+        for (int64_t j = 0; j < n; ++j)
+            for (int64_t i = j+1; i < n; ++i)  // lower
+                A( i, j ) = nan("");
+    }
+
+    // Factor A into L L^H or U U^H to get a well-conditioned triangular matrix.
+    // If diag == Unit, the diagonal is replaced; this is still well-conditioned.
+    // First, brute force positive definiteness.
+    for (int64_t i = 0; i < n; ++i) {
+        A( i, i ) += n;
+    }
+    int64_t info = 0;
+    lapack_potrf( to_c_string( uplo ), n, A, lda, &info );
+    require( info == 0 );
+
+    // norms for error check
+    real_t work[1];
+    real_t Anorm = lapack_lantr( "f", to_c_string( uplo ), to_c_string( diag ),
+                                 n, n, A, lda, work );
+    real_t Xnorm = cblas_nrm2( n, x, std::abs(incx) );
+
+    // if row-major, transpose A
+    if (layout == Layout::RowMajor) {
+        for (int64_t j = 0; j < n; ++j) {
+            for (int64_t i = 0; i < j; ++i) {
+                swap( A( i, j ), A( j, i ) );
+            }
+        }
+    }
+
+    blas::device_copy_matrix( n, n, A, lda, dA, lda, queue );
+    blas::device_copy_vector( n, x, abs( incx ), dx, abs( incx ), queue );
+    queue.sync();
+
+    // test error exits
+    assert_throw( blas::trsv( Layout(0), uplo,    trans, diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    Uplo(0), trans, diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    uplo,    Op(0), diag,     n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    uplo,    trans, Diag(0),  n, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    uplo,    trans, diag,    -1, dA, lda, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    uplo,    trans, diag,     n, dA, n-1, dx, incx, queue ), blas::Error );
+    assert_throw( blas::trsv( layout,    uplo,    trans, diag,     n, dA, lda, dx,    0, queue ), blas::Error );
+
+    if (verbose >= 1) {
+        printf( "\n"
+                "A n=%5lld, lda=%5lld, size=%10lld, norm=%.2e\n"
+                "x n=%5lld, inc=%5lld, size=%10lld, norm=%.2e\n",
+                llong( n ), llong( lda ),  llong( size_A ), Anorm,
+                llong( n ), llong( incx ), llong( size_x ), Xnorm );
+    }
+    if (verbose >= 2) {
+        printf( "A = "    ); print_matrix( n, n, A, lda );
+        printf( "x    = " ); print_vector( n, x, incx );
+    }
+
+    // run test
+    testsweeper::flush_cache( params.cache() );
+    double time = get_wtime();
+    blas::trsv( layout, uplo, trans, diag, n, dA, lda, dx, incx, queue );
+    queue.sync();
+    time = get_wtime() - time;
+
+    double gflop = blas::Gflop< scalar_t >::trsv( n );
+    double gbyte = blas::Gbyte< scalar_t >::trsv( n );
+    params.time()   = time * 1000;  // msec
+    params.gflops() = gflop / time;
+    params.gbytes() = gbyte / time;
+
+    blas::device_copy_vector( n, dx, abs( incx ), x, abs( incx ), queue );
+    queue.sync();
+
+    if (verbose >= 2) {
+        printf( "x2   = " ); print_vector( n, x, incx );
+    }
+
+    if (params.check() == 'y') {
+        // run reference
+        testsweeper::flush_cache( params.cache() );
+        time = get_wtime();
+        cblas_trsv( cblas_layout_const(layout),
+                    cblas_uplo_const(uplo),
+                    cblas_trans_const(trans),
+                    cblas_diag_const(diag),
+                    n, A, lda, xref, incx );
+        time = get_wtime() - time;
+
+        params.ref_time()   = time * 1000;  // msec
+        params.ref_gflops() = gflop / time;
+        params.ref_gbytes() = gbyte / time;
+
+        if (verbose >= 2) {
+            printf( "xref = " ); print_vector( n, xref, incx );
+        }
+
+        // check error compared to reference
+        // treat x as 1 x n matrix with ld = incx; k = n is reduction dimension
+        // alpha = 1, beta = 0.
+        real_t error;
+        bool okay;
+        check_gemm( 1, n, n, scalar_t(1), scalar_t(0), Anorm, Xnorm, real_t(0),
+                    xref, std::abs(incx), x, std::abs(incx), verbose, &error, &okay );
+        params.error() = error;
+        params.okay() = okay;
+    }
+
+    delete[] A;
+    delete[] x;
+    delete[] xref;
+
+    blas::device_free( dA, queue );
+    blas::device_free( dx, queue );
+
+    #undef A
+}
+
+// -----------------------------------------------------------------------------
+void test_trsv_device( Params& params, bool run )
+{
+    switch (params.datatype()) {
+        case testsweeper::DataType::Single:
+            test_trsv_device_work< float, float >( params, run );
+            break;
+
+        case testsweeper::DataType::Double:
+            test_trsv_device_work< double, double >( params, run );
+            break;
+
+        case testsweeper::DataType::SingleComplex:
+            test_trsv_device_work< std::complex<float>, std::complex<float> >
+                ( params, run );
+            break;
+
+        case testsweeper::DataType::DoubleComplex:
+            test_trsv_device_work< std::complex<double>, std::complex<double> >
+                ( params, run );
+            break;
+
+        default:
+            throw std::exception();
+            break;
+    }
+}


### PR DESCRIPTION
Added cuBLAS, rocBLAS, and oneMKL wrappers for trmv and trsv. Based on #117.

