### PR TITLE
Remove stray debug print from symv.hh

### DIFF
--- a/include/blas/symv.hh
+++ b/include/blas/symv.hh
@@ -73,7 +73,6 @@ void symv(
     blas::scalar_type<TA, TX, TY> beta,
     TY *y, int64_t incy )
 {
-printf( "%s: %s\n", __func__, __PRETTY_FUNCTION__ );
     typedef blas::scalar_type<TA, TX, TY> scalar_t;
 
     #define A(i_, j_) A[ (i_) + (j_)*lda ]


### PR DESCRIPTION
`include/blas/symv.hh` contains an unconditional diagnostic print in the generic (template) `symv` implementation:

```cpp
printf( "%s: %s\n", __func__, __PRETTY_FUNCTION__ );
```

This has two problems:

1. `__PRETTY_FUNCTION__` is a GCC/Clang extension. Native MSVC builds of any downstream consumer that instantiates the generic `symv` fail with `error C3861: '__PRETTY_FUNCTION__': identifier not found`. (MSVC's closest equivalent is `__FUNCSIG__`.)
2. Even on GCC/Clang it prints a diagnostic to stdout on every generic `symv` call, which looks like leftover debug output rather than intentional behavior.

This PR simply removes the line. If a function-signature diagnostic is wanted here, a portable macro mapping to `__FUNCSIG__` on MSVC would be the alternative — happy to rework in that direction if preferred.

Context: this was found during the RandBLAS native-Windows port ([BallisticLA/RandBLAS#179](https://github.com/BallisticLA/RandBLAS/pull/179)) by Raphael A. Meyer (@RaphaelArkadyMeyerNYU); RandBLAS Windows CI (MSVC 19.51, C++20, oneMKL ILP64) has been building BLAS++ with exactly this change since 2026-07 via a temporary fork branch. Environment tested there: Windows x64, MSVC 19.51, NMake, standalone Intel oneMKL.
